### PR TITLE
dry-run command does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,3 @@ format: mitamae/bin/rubocop
 
 shellcheck:
 	shellcheck setup.sh mitamae/bin/setup
-
-dry-run-linux: dry-run-plum dry-run-bamboo dry-run-pine
-
-dry-run-macos: dry-run-belle
-
-dry-run-%:
-	cd mitamae && DOTFILES_ROLE=$* bin/mitamae dry-run lib/custom_resources.rb roles/$*/default.rb


### PR DESCRIPTION
## Summary

Delete `dry-run` target, since `mitamae dry-run` does not exist. 
Seemingly it's a result of hallucination, merged mistakenly.

## Type of Change

- [ ] New cookbook (package/tool addition)
- [ ] Cookbook update (existing tool configuration change)
- [ ] Role change (variant tier modification)
- [ ] CI / workflow change
- [ ] Dotfile / config change (`.config/`, `.zshrc`, etc.)
- [ ] Documentation
- [x] Bug fix
- [ ] Other

## Platforms Tested

- [ ] macOS (Apple Silicon)
- [ ] Debian / Ubuntu (aarch64)
- [ ] Debian / Ubuntu (x86_64)
- [ ] Docker (specify variant: pine / bamboo / plum)
- [ ] N/A (no platform-specific changes)

## Checklist

- [x] `bundle exec rubocop` passes (if mitamae recipes changed)
- [x] Idempotent: running the recipe twice produces no changes on the second run
- [x] Platform guards (`only_if` / `not_if`) are in place where needed
- [x] No secrets or personal tokens are included
- [x] Documentation updated (if applicable)
- [x] Self-checked with `/review` or similar coding agent command
