### PR TITLE
feat: add zoxide to belle

### DIFF
--- a/mitamae/roles/belle/default.rb
+++ b/mitamae/roles/belle/default.rb
@@ -28,6 +28,7 @@ include_recipe '../../cookbooks/base_tools'
 include_recipe '../../cookbooks/binutils'
 include_recipe '../../cookbooks/starship'
 include_recipe '../../cookbooks/direnv'
+include_recipe '../../cookbooks/zoxide'
 include_recipe '../../cookbooks/lazygit'
 include_recipe '../../cookbooks/alacritty'
 

--- a/mitamae/roles/belle/goss.yaml
+++ b/mitamae/roles/belle/goss.yaml
@@ -12,6 +12,7 @@ gossfile:
   ../../cookbooks/binutils/goss.yaml: {}
   ../../cookbooks/starship/goss.yaml: {}
   ../../cookbooks/direnv/goss.yaml: {}
+  ../../cookbooks/zoxide/goss.yaml: {}
   ../../cookbooks/lazygit/goss.yaml: {}
   ../../cookbooks/cloudflared/goss.yaml: {}
   ../../cookbooks/aria2/goss.yaml: {}


### PR DESCRIPTION
## Summary
- Enable the existing `zoxide` cookbook on the `belle` role and register its goss check.
- Paves the way to migrate this machine off enhancd (separate manual cleanup of `~/.zshrc_specific`).

## Test plan
- [ ] `cd mitamae && bundle exec rubocop` (already clean locally)
- [ ] Run mitamae provisioning on belle and confirm `zoxide --version` succeeds
- [ ] `goss -g mitamae/roles/belle/goss.yaml validate` passes the new zoxide assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)