### PR TITLE
fix(platformio): bump goss timeout for `pio --version`

### DIFF
--- a/mitamae/cookbooks/platformio/goss.yaml
+++ b/mitamae/cookbooks/platformio/goss.yaml
@@ -1,4 +1,4 @@
 command:
   "pio --version":
     exit-status: 0
-    timeout: 5000
+    timeout: 30000


### PR DESCRIPTION
## Summary
- `pio --version` の goss timeout を 5s → 30s に引き上げ
- CI で flaky にコケていたため (cold run だと5秒では足りないことがある)

## Test plan
- [ ] CI (docker.yaml の belle variant) が通ること