### PR TITLE
fix(ci): improve provisioning stability

### DIFF
--- a/mitamae/cookbooks/claude-code/goss.yaml
+++ b/mitamae/cookbooks/claude-code/goss.yaml
@@ -1,4 +1,4 @@
 command:
   claude --version:
     exit-status: 0
-    timeout: 5000
+    timeout: 30000

--- a/mitamae/cookbooks/flatcam/default.rb
+++ b/mitamae/cookbooks/flatcam/default.rb
@@ -1,11 +1,15 @@
 if node[:platform] == 'darwin'
   # The formula installs flatcam-evo's Python deps via pip, including gdal.
-  # gdal ships no PyPI wheels (upstream policy), so it must build from source
-  # against the Homebrew gdal C library, and that build fails depending on
-  # the host's exact gdal/Python/headers state. The fix has to come from
-  # upstream — until then, don't sink provisioning over it.
-  package 'tomoyanonymous/homebrew-flatcam/flatcam-evo' do
-    ignore_failure true
+  # gdal ships no PyPI wheels, so it must build from source against the
+  # Homebrew gdal C library, and that build fails depending on the host's
+  # gdal/Python/headers state. The fix has to come from upstream — until
+  # then, don't sink provisioning over it.
+  #
+  # mitamae's `package` resource has no `ignore_failure`, so shell out via
+  # `execute` and swallow a non-zero brew exit with `|| true`.
+  execute 'Install flatcam-evo (best effort)' do
+    command 'brew install tomoyanonymous/homebrew-flatcam/flatcam-evo || true'
+    not_if 'brew list --formula tomoyanonymous/homebrew-flatcam/flatcam-evo >/dev/null 2>&1'
   end
 else
   Mitamae.logger.error "unsupported platform #{node[:platform]}: #{__FILE__}:#{__LINE__}"

--- a/mitamae/cookbooks/flatcam/default.rb
+++ b/mitamae/cookbooks/flatcam/default.rb
@@ -1,5 +1,12 @@
 if node[:platform] == 'darwin'
-  package 'tomoyanonymous/homebrew-flatcam/flatcam-evo'
+  # The formula installs flatcam-evo's Python deps via pip, including gdal.
+  # gdal ships no PyPI wheels (upstream policy), so it must build from source
+  # against the Homebrew gdal C library, and that build fails depending on
+  # the host's exact gdal/Python/headers state. The fix has to come from
+  # upstream — until then, don't sink provisioning over it.
+  package 'tomoyanonymous/homebrew-flatcam/flatcam-evo' do
+    ignore_failure true
+  end
 else
   Mitamae.logger.error "unsupported platform #{node[:platform]}: #{__FILE__}:#{__LINE__}"
   exit 1

--- a/mitamae/cookbooks/google-cloud-sdk/goss.yaml
+++ b/mitamae/cookbooks/google-cloud-sdk/goss.yaml
@@ -1,4 +1,4 @@
 command:
   gcloud --version:
     exit-status: 0
-    timeout: 5000
+    timeout: 30000

--- a/mitamae/cookbooks/huggingface-cli/goss.yaml
+++ b/mitamae/cookbooks/huggingface-cli/goss.yaml
@@ -1,4 +1,4 @@
 command:
   "hf --version":
     exit-status: 0
-    timeout: 15000
+    timeout: 30000

--- a/mitamae/cookbooks/kotlin-lsp/goss.yaml
+++ b/mitamae/cookbooks/kotlin-lsp/goss.yaml
@@ -1,4 +1,4 @@
 command:
   kotlin-lsp --version:
     exit-status: 0
-    timeout: 10000
+    timeout: 30000

--- a/mitamae/cookbooks/kotlin/goss.yaml
+++ b/mitamae/cookbooks/kotlin/goss.yaml
@@ -1,4 +1,4 @@
 command:
   kotlin -version:
     exit-status: 0
-    timeout: 5000
+    timeout: 30000

--- a/mitamae/cookbooks/ollama/goss.yaml
+++ b/mitamae/cookbooks/ollama/goss.yaml
@@ -1,4 +1,4 @@
 command:
   ollama --version:
     exit-status: 0
-    timeout: 5000
+    timeout: 30000

--- a/mitamae/cookbooks/opencode/goss.yaml
+++ b/mitamae/cookbooks/opencode/goss.yaml
@@ -1,4 +1,4 @@
 command:
   opencode --version:
     exit-status: 0
-    timeout: 15000
+    timeout: 30000

--- a/mitamae/cookbooks/prisma-language-server/goss.yaml
+++ b/mitamae/cookbooks/prisma-language-server/goss.yaml
@@ -1,4 +1,4 @@
 command:
   prisma-language-server --version:
     exit-status: 0
-    timeout: 5000
+    timeout: 30000

--- a/mitamae/cookbooks/pylsp/goss.yaml
+++ b/mitamae/cookbooks/pylsp/goss.yaml
@@ -1,4 +1,4 @@
 command:
   pylsp --version:
     exit-status: 0
-    timeout: 15000
+    timeout: 30000

--- a/mitamae/cookbooks/typescript-language-server/goss.yaml
+++ b/mitamae/cookbooks/typescript-language-server/goss.yaml
@@ -1,4 +1,4 @@
 command:
   typescript-language-server --version:
     exit-status: 0
-    timeout: 5000
+    timeout: 30000


### PR DESCRIPTION
## Summary
Improve provisioning/CI reliability by addressing two unrelated sources of flakes.

### 1. goss timeouts on slow-startup runtimes (30s)
Standardize on 30s for any tool whose \`--version\` startup is dominated by an interpreted runtime. Native compiled binaries keep their 5s default.

| Cookbook | Was | Reason |
|---|---|---|
| google-cloud-sdk | 5s | Python (gcloud cold start ~10s+) |
| prisma-language-server | 5s | Node LSP |
| typescript-language-server | 5s | Node LSP |
| kotlin | 5s | JVM cold start |
| kotlin-lsp | 10s | JVM (consistency) |
| claude-code | 5s | Node CLI |
| ollama | 5s | Go binary, but model warm-up can be slow |
| huggingface-cli | 15s | Python (consistency) |
| opencode | 15s | Node (consistency) |
| pylsp | 15s | Python (consistency) |

### 2. flatcam-evo: tolerate gdal wheel build failure
The flatcam-evo formula pip-installs gdal, which has no PyPI wheels at all (upstream policy). The source build fails depending on the host's gdal/Python/headers state. Mark the install as best-effort so a build failure does not sink the rest of provisioning.

## Test plan
- [ ] CI passes on belle (the flatcam build no longer aborts the role)
- [ ] CI passes on hercules / pc137 (timeout bumps don't break anything)