### PR TITLE
deps: upgrade ubuntu to 26.04 Resolute Raccoon

### DIFF
--- a/docker/Dockerfile.bamboo
+++ b/docker/Dockerfile.bamboo
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 LABEL org.opencontainers.image.source=https://github.com/yuseiito/dotfiles
 LABEL org.opencontainers.image.description="Yusei's dotfiles Container. Variant `bamboo`"

--- a/docker/Dockerfile.pine
+++ b/docker/Dockerfile.pine
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 LABEL org.opencontainers.image.source=https://github.com/yuseiito/dotfiles
 LABEL org.opencontainers.image.description="Yusei's dotfiles Container. Variant `pine`"

--- a/lxc/README.md
+++ b/lxc/README.md
@@ -24,8 +24,8 @@ sudo tar -xzf "oras_${ORAS_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin oras
 | Variant | Base OS | GHCR Tag |
 |---|---|---|
 | `plum` | Debian Bookworm | `ghcr.io/yuseiito/yuseiito-dev-lxc:plum-latest` |
-| `bamboo` | Ubuntu 24.04 | `ghcr.io/yuseiito/yuseiito-dev-lxc:bamboo-latest` |
-| `pine` | Ubuntu 24.04 | `ghcr.io/yuseiito/yuseiito-dev-lxc:pine-latest` |
+| `bamboo` | Ubuntu 26.04 | `ghcr.io/yuseiito/yuseiito-dev-lxc:bamboo-latest` |
+| `pine` | Ubuntu 26.04 | `ghcr.io/yuseiito/yuseiito-dev-lxc:pine-latest` |
 
 Branch builds are tagged as `<variant>-<branch-name>` (slashes replaced with hyphens).
 

--- a/scripts/build-lxc.sh
+++ b/scripts/build-lxc.sh
@@ -17,9 +17,9 @@ case "${VARIANT}" in
     COMPONENTS=main,non-free
     ;;
   bamboo | pine)
-    SUITE=noble
+    SUITE=resolute
     OS=ubuntu
-    RELEASE=24.04
+    RELEASE=26.04
     TARGET_USER=ubuntu
     COMPONENTS=main,universe,multiverse
     ;;


### PR DESCRIPTION
## Summary

Upgrade ubuntu to 26.04

## Type of Change

- [ ] New cookbook (package/tool addition)
- [ ] Cookbook update (existing tool configuration change)
- [x] Role change (variant tier modification)
- [x] CI / workflow change
- [ ] Dotfile / config change (`.config/`, `.zshrc`, etc.)
- [ ] Documentation
- [ ] Bug fix
- [x] Other

## Platforms Tested

- [ ] macOS (Apple Silicon)
- [ ] Debian / Ubuntu (aarch64)
- [ ] Debian / Ubuntu (x86_64)
- [ ] Docker (specify variant: pine / bamboo / plum)
- [ ] N/A (no platform-specific changes)

## Checklist

- [ ] `bundle exec rubocop` passes (if mitamae recipes changed)
- [ ] Idempotent: running the recipe twice produces no changes on the second run
- [ ] Platform guards (`only_if` / `not_if`) are in place where needed
- [ ] No secrets or personal tokens are included
- [x] Documentation updated (if applicable)
- [ ] Self-checked with `/review` or similar coding agent command
