### PR TITLE
Feature/tuning neo tree

### DIFF
--- a/.config/nvim/lua/plugins/neo-tree.lua
+++ b/.config/nvim/lua/plugins/neo-tree.lua
@@ -21,14 +21,12 @@ return {
   config = function()
     require("neo-tree").setup({
       filesystem = {
-        hijack_netrw_behavior = "open_default",
         filtered_items = {
           visible = true,
           hide_dotfiles = false,
           hide_gitignored = false,
         },
-      },
-      window = { width = 40 },
+      }
     })
   end,
 }

--- a/.config/nvim/lua/plugins/neo-tree.lua
+++ b/.config/nvim/lua/plugins/neo-tree.lua
@@ -22,9 +22,13 @@ return {
     require("neo-tree").setup({
       filesystem = {
         filtered_items = {
-          visible = true,
+          -- Hide gitignored files to reduce libuv watchers and avoid EMFILE errors.
+          -- Press 'H' to toggle visibility when needed.
           hide_dotfiles = false,
-          hide_gitignored = false,
+          hide_gitignored = true,
+          hide_by_name = {
+            ".git",
+          },
         },
       }
     })


### PR DESCRIPTION
This pull request updates the Neo-tree plugin configuration to improve performance and reduce file watcher errors by hiding gitignored files by default. Users can still toggle the visibility of these files when needed.

**Neo-tree plugin configuration improvements:**

* Changed the `filtered_items` settings to hide gitignored files and the `.git` directory by default
  * This helps reduce libuv watchers and avoid EMFILE errors. Users can press 'H' to toggle visibility. (`.config/nvim/lua/plugins/neo-tree.lua`)
* Removed the `hijack_netrw_behavior` and `window` width settings from the configuration. 
