### PR TITLE
Create .editorconfig for lua indentation alignment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.lua]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This pull request makes a small configuration update to the `.editorconfig` file, specifying that all `.lua` files should use 2 spaces for indentation.