### PR TITLE
Fix broken `gf` keybinding for formatting

### DIFF
--- a/.config/nvim/lua/lsp/lsp.lua
+++ b/.config/nvim/lua/lsp/lsp.lua
@@ -9,7 +9,7 @@ end
 vim.api.nvim_create_user_command("Format", fn_format, { nargs = 0 })
 
 vim.keymap.set('n', 'K',  '<cmd>lua vim.lsp.buf.hover()<CR>')
-vim.keymap.set('n', 'gf', '<cmd>lua vim.lsp.buf.formatting()<CR>')
+vim.keymap.set('n', 'gf', '<cmd>lua vim.lsp.buf.format()<CR>')
 vim.keymap.set('n', 'gr', '<cmd>lua vim.lsp.buf.references()<CR>')
 vim.keymap.set('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>')
 vim.keymap.set('n', 'gD', '<cmd>lua vim.lsp.buf.declaration()<CR>')


### PR DESCRIPTION
This pull request updates the key mapping for formatting in the Neovim LSP configuration to use the newer `vim.lsp.buf.format()` function instead of the deprecated `vim.lsp.buf.formatting()`.

- Updated the `'gf'` normal mode key mapping in `.config/nvim/lua/lsp/lsp.lua` to use `vim.lsp.buf.format()` for formatting, replacing the deprecated `vim.lsp.buf.formatting()`.