### PR TITLE
Neotree configuration adjustment

### DIFF
--- a/.config/nvim/lua/plugins/neo-tree.lua
+++ b/.config/nvim/lua/plugins/neo-tree.lua
@@ -15,6 +15,8 @@ return {
   },
   config = function()
     require("neo-tree").setup({
+      -- Quit neovim when neo-tree window is the last one remaining.
+      close_if_last_window = true,
       filesystem = {
         filtered_items = {
           -- Hide gitignored files to reduce libuv watchers and avoid EMFILE errors.

--- a/.config/nvim/lua/plugins/neo-tree.lua
+++ b/.config/nvim/lua/plugins/neo-tree.lua
@@ -4,7 +4,7 @@ return {
   "nvim-neo-tree/neo-tree.nvim",
   enabled = features.basic_amenities,
   branch = "v3.x",
-  cmd = "Neotree",
+  lazy = false,
   keys = {
     { "<C-n>", "<cmd>Neotree toggle reveal<CR>", desc = "Toggle file tree" },
   },
@@ -13,11 +13,6 @@ return {
     "nvim-tree/nvim-web-devicons",
     "MunifTanjim/nui.nvim",
   },
-  init = function()
-    -- Hijack netrw so opening a directory shows neo-tree
-    vim.g.loaded_netrw = 1
-    vim.g.loaded_netrwPlugin = 1
-  end,
   config = function()
     require("neo-tree").setup({
       filesystem = {

--- a/.config/nvim/lua/plugins/neo-tree.lua
+++ b/.config/nvim/lua/plugins/neo-tree.lua
@@ -18,6 +18,10 @@ return {
       -- Quit neovim when neo-tree window is the last one remaining.
       close_if_last_window = true,
       filesystem = {
+        -- Let the tree focus on the file opened in the current buffer.
+        follow_current_file = {
+          enabled = true,
+        },
         filtered_items = {
           -- Hide gitignored files to reduce libuv watchers and avoid EMFILE errors.
           -- Press 'H' to toggle visibility when needed.


### PR DESCRIPTION
This pull request updates the configuration for the `nvim-neo-tree/neo-tree.nvim` plugin in Neovim. The main focus is on improving user experience by ensuring the file tree is always available and better integrated, as well as optimizing how files and windows are managed.

Key configuration and usability improvements:

* Plugin loading and command behavior:
  - Changed the plugin to load eagerly (`lazy = false`) instead of only on the `Neotree` command, ensuring the file tree functionality is always available.

* Window and file focus enhancements:
  - Enabled the `close_if_last_window` option so that Neovim will quit if the neo-tree window is the last one open, streamlining window management.
  - Enabled `follow_current_file` so the tree will automatically focus on the file opened in the current buffer, improving navigation.

* Code cleanup:
  - Removed the `init` function that hijacked netrw, simplifying the configuration and relying on neo-tree's own setup.