### PR TITLE
fix(nvim): showmode=false

### DIFF
--- a/.config/nvim/lua/base.lua
+++ b/.config/nvim/lua/base.lua
@@ -24,6 +24,7 @@ vim.opt.tabstop = 4
 vim.opt.shiftwidth = 4
 vim.opt.expandtab = true
 vim.opt.list = true
+vim.opt.showmode = false -- Don't show the mode to avoid conflict with statusline plugins
 
 -- Remember the place of cursor
 vim.api.nvim_create_autocmd("BufReadPost", {


### PR DESCRIPTION
This pull request makes a small configuration improvement to your Neovim setup by disabling the default mode display, which helps avoid conflicts with statusline plugins.

* Set `vim.opt.showmode = false` in `.config/nvim/lua/base.lua` to prevent Neovim from displaying the current mode, as this is handled by statusline plugins (i.e `lualine`) .