### PR TITLE
feat(telescope): `<leader> fr` to resume telescope finder

### DIFF
--- a/.config/nvim/lua/plugins/telescope.lua
+++ b/.config/nvim/lua/plugins/telescope.lua
@@ -9,6 +9,7 @@ return {
     { "<leader>fg", function() require("telescope.builtin").live_grep() end },
     { "<leader>fb", function() require("telescope.builtin").buffers() end },
     { "<leader>fh", function() require("telescope.builtin").help_tags() end },
+    { "<leader>fr", "<cmd>Telescope resume<CR>", desc = "Resume the last finder." },
   },
   dependencies = { "nvim-lua/plenary.nvim" },
 }


### PR DESCRIPTION
This pull request introduces a minor enhancement to the Telescope plugin configuration in Neovim by adding a new keybinding to quickly resume the last Telescope finder session.

- Added a keybinding (`<leader>fr`) to trigger `Telescope resume`, allowing users to resume the last finder session easily. (`.config/nvim/lua/plugins/telescope.lua`)