### PR TITLE
fix(nvim): lazy set colorscheme after plugin load

### DIFF
--- a/.config/nvim/lua/color.lua
+++ b/.config/nvim/lua/color.lua
@@ -1,4 +1,3 @@
 -- Configure 24-bit true color
 vim.opt.termguicolors = true
 vim.opt.background = "dark"
-vim.cmd("colorscheme onedark")

--- a/.config/nvim/lua/plugins/colorscheme.lua
+++ b/.config/nvim/lua/plugins/colorscheme.lua
@@ -5,5 +5,6 @@ return {
   config = function()
     require("onedark").setup({ style = "dark" })
     require("onedark").load()
+    vim.cmd([[colorscheme onedark]])
   end,
 }


### PR DESCRIPTION
This pull request updates how the `onedark` colorscheme is loaded in the Neovim configuration. The main change is to ensure that the colorscheme is applied as part of the plugin configuration, rather than being set globally.

**Colorscheme configuration improvements:**

* Moved the `colorscheme onedark` command from the global configuration in `.config/nvim/lua/color.lua` to the plugin-specific configuration block in `.config/nvim/lua/plugins/colorscheme.lua` to ensure proper application and avoid conflicts. 