### PR TITLE
fix: set hostname `-s` flag to omit `.local`

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ cd mitamae
 bin/setup
 
 # Determine the target role based on the DOTFILES_ROLE environment variable or the hostname
-LOWERCASE_HOSTNAME=$(hostname | tr '[:upper:]' '[:lower:]')
+LOWERCASE_HOSTNAME=$(hostname -s | tr '[:upper:]' '[:lower:]')
 
 # If DOTFILES_ROLE is set, use it; otherwise, use the lowercase hostname
 ROLE="${DOTFILES_ROLE:-$LOWERCASE_HOSTNAME}"


### PR DESCRIPTION
This pull request makes a small update to how the hostname is determined in the `setup.sh` script. The script now uses the short hostname (`hostname -s`) instead of the full hostname when setting the `LOWERCASE_HOSTNAME` variable.