### PR TITLE
Add keybinds for exiting terminal mode in Neo-tree

### DIFF
--- a/.config/nvim/lua/key.lua
+++ b/.config/nvim/lua/key.lua
@@ -20,3 +20,5 @@ vim.keymap.set('n', '<Tab><Tab>', 'gT')
 for i = 1, 9, 1 do
   vim.keymap.set('n', '<Tab>' .. i, i .. 'gt', { desc = string.format("Jump to %d-th tab.", i) })
 end
+
+vim.keymap.set('t', '<C-q>', '<C-\\><C-n>', { desc = 'Exit terminal mode' })

--- a/.config/nvim/lua/plugins/neo-tree.lua
+++ b/.config/nvim/lua/plugins/neo-tree.lua
@@ -17,6 +17,13 @@ return {
     require("neo-tree").setup({
       -- Quit neovim when neo-tree window is the last one remaining.
       close_if_last_window = true,
+      window = {
+        mappings = {
+          ["v"] = "open_vsplit",
+          ["l"] = "open",
+          ["h"] = "close_node"
+        }
+      },
       filesystem = {
         -- Let the tree focus on the file opened in the current buffer.
         follow_current_file = {


### PR DESCRIPTION
This pull request introduces improvements to the Neovim configuration, focusing on enhancing usability in terminal and file navigation workflows.

**Key changes:**

### Terminal usability

* Added a key mapping in terminal mode (`<C-q>`) to exit to normal mode, making it easier to switch out of terminal input. (`.config/nvim/lua/key.lua`)

### Neo-tree plugin enhancements

* Configured custom window key mappings for Neo-tree:  
  * `"v"` opens a file in a vertical split,  
  * `"l"` opens a file,  
  * `"h"` closes a node.  
  This streamlines navigation and file management within the Neo-tree file explorer. (`.config/nvim/lua/plugins/neo-tree.lua`)