### PR TITLE
Add git-commit-claude cookbook and configuration updates

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -1,0 +1,6 @@
+customCommands:
+  - key: '<c-a>'
+    context: 'files'
+    command: 'git ccc'
+    description: 'Generate commit message with Claude'
+    output: terminal

--- a/mitamae/cookbooks/git-commit-claude/default.rb
+++ b/mitamae/cookbooks/git-commit-claude/default.rb
@@ -1,0 +1,19 @@
+include_recipe '../claude-code'
+
+cookbook_dir = File.dirname(__FILE__)
+script_src = File.join(cookbook_dir, 'files', 'git-commit-claude')
+bin_dir = "#{ENV['HOME']}/.local/bin"
+script_dest = "#{bin_dir}/git-commit-claude"
+alias_dest = "#{bin_dir}/git-ccc"
+
+directory bin_dir
+
+link script_dest do
+  to script_src
+  force true
+end
+
+link alias_dest do
+  to script_dest
+  force true
+end

--- a/mitamae/cookbooks/git-commit-claude/files/git-commit-claude
+++ b/mitamae/cookbooks/git-commit-claude/files/git-commit-claude
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Generate a Git commit message draft with Claude, then open $EDITOR for review.
+# Usage: git commit-claude [extra hint...]
+#        git ccc [extra hint...]
+set -euo pipefail
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "git-commit-claude: 'claude' CLI not found in PATH" >&2
+  exit 127
+fi
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "git-commit-claude: not inside a git repository" >&2
+  exit 1
+fi
+
+if git diff --cached --quiet; then
+  echo "git-commit-claude: no staged changes (use 'git add' first)" >&2
+  exit 1
+fi
+
+user_hint="${*:-}"
+diff_content="$(git diff --cached)"
+recent_log="$(git log -n 20 --pretty=format:'%s%n%n%b%n---' 2>/dev/null || true)"
+
+prompt="You are generating a Git commit message.
+
+Rules:
+- Match the LANGUAGE of the recent commits below (English/Japanese/etc). Do not switch languages.
+- Match the tone, prefix style (e.g. 'feat:', 'fix:'), and length conventions visible in those commits.
+- First line: <= 72 chars, imperative mood, no trailing period.
+- If the change is non-trivial, add a blank line and a short body explaining *why*.
+- Output ONLY the commit message — no code fences, no preamble, no quotes.
+
+Recent commits (style + language reference):
+${recent_log}
+
+${user_hint:+Additional user hint (incorporate if relevant): ${user_hint}}
+
+Staged diff:
+${diff_content}"
+
+draft_file="$(git rev-parse --git-dir)/COMMIT_EDITMSG_CLAUDE"
+trap 'rm -f "$draft_file"' EXIT
+
+echo "git-commit-claude: generating draft with Claude..." >&2
+if ! claude -p "$prompt" >"$draft_file"; then
+  echo "git-commit-claude: claude CLI failed" >&2
+  exit 1
+fi
+
+exec git commit -e -F "$draft_file"

--- a/mitamae/cookbooks/git-commit-claude/files/git-commit-claude
+++ b/mitamae/cookbooks/git-commit-claude/files/git-commit-claude
@@ -2,7 +2,13 @@
 # Generate a Git commit message draft with Claude, then open $EDITOR for review.
 # Usage: git commit-claude [extra hint...]
 #        git ccc [extra hint...]
+# Env vars:
+#   GIT_CCC_MODEL  (default: sonnet)  — claude --model alias or full name
+#   GIT_CCC_EFFORT (default: low)     — low|medium|high|xhigh|max
 set -euo pipefail
+
+: "${GIT_CCC_MODEL:=sonnet}"
+: "${GIT_CCC_EFFORT:=low}"
 
 if ! command -v claude >/dev/null 2>&1; then
   echo "git-commit-claude: 'claude' CLI not found in PATH" >&2
@@ -43,8 +49,12 @@ ${diff_content}"
 draft_file="$(git rev-parse --git-dir)/COMMIT_EDITMSG_CLAUDE"
 trap 'rm -f "$draft_file"' EXIT
 
-echo "git-commit-claude: generating draft with Claude..." >&2
-if ! claude -p "$prompt" >"$draft_file"; then
+echo "git-commit-claude: generating draft (model=$GIT_CCC_MODEL effort=$GIT_CCC_EFFORT)..." >&2
+if ! claude -p \
+    --model "$GIT_CCC_MODEL" \
+    --effort "$GIT_CCC_EFFORT" \
+    --no-session-persistence \
+    "$prompt" >"$draft_file"; then
   echo "git-commit-claude: claude CLI failed" >&2
   exit 1
 fi

--- a/mitamae/cookbooks/git-commit-claude/goss.yaml
+++ b/mitamae/cookbooks/git-commit-claude/goss.yaml
@@ -1,0 +1,10 @@
+command:
+  test -L "$HOME/.local/bin/git-commit-claude":
+    exit-status: 0
+    timeout: 5000
+  test -L "$HOME/.local/bin/git-ccc":
+    exit-status: 0
+    timeout: 5000
+  test -x "$HOME/.local/bin/git-commit-claude":
+    exit-status: 0
+    timeout: 5000

--- a/mitamae/cookbooks/lazygit/default.rb
+++ b/mitamae/cookbooks/lazygit/default.rb
@@ -20,3 +20,5 @@ elsif %w[ubuntu debian].include?(node[:platform])
     not_if "lazygit --version 2>/dev/null | grep -q '#{lazygit_version}'"
   end
 end
+
+dotconfig 'lazygit'

--- a/mitamae/cookbooks/zsh/files/.zshenv
+++ b/mitamae/cookbooks/zsh/files/.zshenv
@@ -2,6 +2,11 @@
 # ~/.zshenv is sourced by zsh for ALL invocations: login, non-login, interactive, non-interactive.
 # Keep only PATH and environment variable exports here.
 
+# Force XDG default so macOS-aware tools (e.g. lazygit) use ~/.config instead of
+# ~/Library/Application Support. XDG_CONFIG_HOME defaults to ~/.config when unset,
+# so this is a no-op for tools that already check XDG.
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+
 # nodenv
 if [ -d "$HOME/.nodenv" ]; then
   export PATH="$HOME/.nodenv/shims:$HOME/.nodenv/bin:${PATH}"

--- a/mitamae/roles/belle/default.rb
+++ b/mitamae/roles/belle/default.rb
@@ -48,6 +48,7 @@ include_recipe '../../cookbooks/ollama'
 include_recipe '../../cookbooks/huggingface-cli'
 include_recipe '../../cookbooks/aider'
 include_recipe '../../cookbooks/claude-code'
+include_recipe '../../cookbooks/git-commit-claude'
 include_recipe '../../cookbooks/gemini-cli'
 include_recipe '../../cookbooks/opencode'
 

--- a/mitamae/roles/hercules/default.rb
+++ b/mitamae/roles/hercules/default.rb
@@ -46,6 +46,7 @@ include_recipe '../../cookbooks/ollama'
 include_recipe '../../cookbooks/huggingface-cli'
 include_recipe '../../cookbooks/aider'
 include_recipe '../../cookbooks/claude-code'
+include_recipe '../../cookbooks/git-commit-claude'
 include_recipe '../../cookbooks/gemini-cli'
 include_recipe '../../cookbooks/opencode'
 

--- a/mitamae/roles/pc137/default.rb
+++ b/mitamae/roles/pc137/default.rb
@@ -47,6 +47,7 @@ include_recipe '../../cookbooks/ollama'
 include_recipe '../../cookbooks/huggingface-cli'
 include_recipe '../../cookbooks/aider'
 include_recipe '../../cookbooks/claude-code'
+include_recipe '../../cookbooks/git-commit-claude'
 include_recipe '../../cookbooks/gemini-cli'
 include_recipe '../../cookbooks/opencode'
 

--- a/mitamae/roles/pine/default.rb
+++ b/mitamae/roles/pine/default.rb
@@ -30,6 +30,7 @@ include_recipe '../../cookbooks/cfn-lint'
 
 # AI & Coding Assistants
 include_recipe '../../cookbooks/ollama'
+include_recipe '../../cookbooks/git-commit-claude'
 
 # Languages & Runtimes
 include_recipe '../../cookbooks/kotlin'


### PR DESCRIPTION
This pull request introduces a new automated tool for generating Git commit messages using Claude, integrates it into the system configuration, and adds a convenient alias and editor workflow. It also ensures that the tool is installed and available across relevant roles, with configuration and verification steps to support its use. Additionally, it improves environment consistency for XDG-compliant tools like lazygit.

**Git Commit Message Automation Integration:**

* Added a new `git-commit-claude` script that generates Git commit message drafts using Claude, matching the style and language of recent commits, and opens the message in the user's editor for review. The script supports configuration via environment variables and provides error handling for common issues. (`mitamae/cookbooks/git-commit-claude/files/git-commit-claude`)
* Configured installation of `git-commit-claude` and a `git ccc` alias in `~/.local/bin`, ensuring both are symlinked and available for use. (`mitamae/cookbooks/git-commit-claude/default.rb`)
* Added Goss tests to verify that the `git-commit-claude` and `git-ccc` links exist and are executable. (`mitamae/cookbooks/git-commit-claude/goss.yaml`)
* Included the `git-commit-claude` cookbook in multiple host roles, ensuring the tool is provisioned on all relevant systems. (`mitamae/roles/belle/default.rb`, `mitamae/roles/hercules/default.rb`, `mitamae/roles/pc137/default.rb`, `mitamae/roles/pine/default.rb`) [[1]](diffhunk://#diff-b8a76639db5b8dd4c3418cbf3e20ef617aee66318e91aaf63f279c6100870a45R51) [[2]](diffhunk://#diff-899810f64e2788a5255b7e45356bea8ece86b9da7a216bce8ac0e9c01f29b7bbR49) [[3]](diffhunk://#diff-b95598fc8375b30966800dc378bd76d3aabd7c69a102337db09c0f5f57e196c0R50) [[4]](diffhunk://#diff-5e63726fb3da9f4a524690f18e4dbc1101fd44c58894b76d83a0aed237312096R33)

**lazygit Integration and Environment Consistency:**

* Added a custom command to lazygit that binds `<c-a>` in the files context to run `git ccc`, enabling quick commit message generation with Claude from within lazygit. (`.config/lazygit/config.yml`)
* Ensured lazygit is configured via a dotconfig resource, supporting customizations like the new command. (`mitamae/cookbooks/lazygit/default.rb`)
* Set `XDG_CONFIG_HOME` in `.zshenv` to standardize config locations for XDG-aware tools (like lazygit) across platforms. (`mitamae/cookbooks/zsh/files/.zshenv`)