### PR TITLE
Add some claude code plugins

### DIFF
--- a/mitamae/cookbooks/claude-code/files/settings.json
+++ b/mitamae/cookbooks/claude-code/files/settings.json
@@ -206,6 +206,7 @@
       "Bash(cargo install *)"
     ]
   },
+  "model": "opus",
   "hooks": {
     "Notification": [
       {
@@ -218,7 +219,6 @@
       }
     ]
   },
-  "model": "opus",
   "statusLine": {
     "type": "command",
     "command": "sh ~/.claude/statusline-command.sh"
@@ -236,7 +236,11 @@
     "rust-analyzer-lsp@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
-    "kotlin-lsp@claude-plugins-official": true
+    "kotlin-lsp@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "playground@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "pm-skills": {


### PR DESCRIPTION
This pull request updates the `settings.json` configuration for the Claude Code environment. The main changes involve plugin management and a small adjustment to the model configuration.

**Plugin management:**

* Added several official plugins to the `enabledPlugins` list: `frontend-design@claude-plugins-official`, `playground@claude-plugins-official`, `playwright@claude-plugins-official`, and `pyright-lsp@claude-plugins-official`. This expands the available features for frontend design, code playgrounds, browser automation, and Python language support.