### PR TITLE
Herculesにdockerを入れる

### DIFF
--- a/mitamae/roles/hercules/default.rb
+++ b/mitamae/roles/hercules/default.rb
@@ -43,6 +43,7 @@ include_recipe '../../cookbooks/nmap'
 include_recipe '../../cookbooks/awscli'
 include_recipe '../../cookbooks/cfn-lint'
 include_recipe '../../cookbooks/gh'
+include_recipe '../../cookbooks/docker'
 
 # AI & Coding Assistants
 include_recipe '../../cookbooks/ollama'

--- a/mitamae/roles/hercules/goss.yaml
+++ b/mitamae/roles/hercules/goss.yaml
@@ -20,6 +20,7 @@ gossfile:
   ../../cookbooks/awscli/goss.yaml: {}
   ../../cookbooks/cfn-lint/goss.yaml: {}
   ../../cookbooks/gh/goss.yaml: {}
+  ../../cookbooks/docker/goss.yaml: {}
   ../../cookbooks/ollama/goss.yaml: {}
   ../../cookbooks/huggingface-cli/goss.yaml: {}
   ../../cookbooks/aider/goss.yaml: {}


### PR DESCRIPTION
## Summary
Include the docker cookbook in the hercules role so the host gets Docker Engine (Linux) / Docker Desktop (macOS), matching the bamboo and pc137 roles. Register the docker goss check accordingly.

## Type of Change

- [ ] New cookbook (package/tool addition)
- [ ] Cookbook update (existing tool configuration change)
- [x] Role change (variant tier modification)
- [ ] CI / workflow change
- [ ] Dotfile / config change (`.config/`, `.zshrc`, etc.)
- [ ] Documentation
- [ ] Bug fix
- [ ] Other

## Platforms Tested

- [x] macOS (Apple Silicon)
- [ ] Debian / Ubuntu (aarch64)
- [ ] Debian / Ubuntu (x86_64)
- [ ] Docker (specify variant: pine / bamboo / plum)
- [ ] N/A (no platform-specific changes)

## Checklist

- [x] `bundle exec rubocop` passes (if mitamae recipes changed)
- [ ] Idempotent: running the recipe twice produces no changes on the second run
- [x] Platform guards (`only_if` / `not_if`) are in place where needed
- [ ] No secrets or personal tokens are included
- [x] Documentation updated (if applicable)
- [ ] Self-checked with `/review` or similar coding agent command
