### PR TITLE
feat: add devcontainer CLI to hercules, belle, pc137, bamboo, pine

### DIFF
--- a/mitamae/cookbooks/devcontainer-cli/default.rb
+++ b/mitamae/cookbooks/devcontainer-cli/default.rb
@@ -1,0 +1,6 @@
+# devcontainer CLI is distributed only as an npm package; no maintained
+# Homebrew or apt formula exists, so install via npm on every platform.
+# Ref: https://github.com/devcontainers/cli
+npm_global_package '@devcontainers/cli' do
+  bin_name 'devcontainer'
+end

--- a/mitamae/cookbooks/devcontainer-cli/goss.yaml
+++ b/mitamae/cookbooks/devcontainer-cli/goss.yaml
@@ -1,0 +1,4 @@
+command:
+  devcontainer --version:
+    exit-status: 0
+    timeout: 30000

--- a/mitamae/roles/bamboo/default.rb
+++ b/mitamae/roles/bamboo/default.rb
@@ -30,6 +30,7 @@ include_recipe '../../cookbooks/lazygit'
 include_recipe '../../cookbooks/awscli'
 include_recipe '../../cookbooks/gh'
 include_recipe '../../cookbooks/docker'
+include_recipe '../../cookbooks/devcontainer-cli'
 
 # AI & Coding Assistants
 include_recipe '../../cookbooks/huggingface-cli'

--- a/mitamae/roles/bamboo/goss.yaml
+++ b/mitamae/roles/bamboo/goss.yaml
@@ -10,6 +10,7 @@ gossfile:
   ../../cookbooks/awscli/goss.yaml: {}
   ../../cookbooks/gh/goss.yaml: {}
   ../../cookbooks/docker/goss.yaml: {}
+  ../../cookbooks/devcontainer-cli/goss.yaml: {}
   ../../cookbooks/huggingface-cli/goss.yaml: {}
   ../../cookbooks/aider/goss.yaml: {}
   ../../cookbooks/claude-code/goss.yaml: {}

--- a/mitamae/roles/belle/default.rb
+++ b/mitamae/roles/belle/default.rb
@@ -45,6 +45,7 @@ include_recipe '../../cookbooks/nikto'
 include_recipe '../../cookbooks/awscli'
 include_recipe '../../cookbooks/cfn-lint'
 include_recipe '../../cookbooks/gh'
+include_recipe '../../cookbooks/docker'
 include_recipe '../../cookbooks/devcontainer-cli'
 
 # AI & Coding Assistants

--- a/mitamae/roles/belle/default.rb
+++ b/mitamae/roles/belle/default.rb
@@ -45,6 +45,7 @@ include_recipe '../../cookbooks/nikto'
 include_recipe '../../cookbooks/awscli'
 include_recipe '../../cookbooks/cfn-lint'
 include_recipe '../../cookbooks/gh'
+include_recipe '../../cookbooks/devcontainer-cli'
 
 # AI & Coding Assistants
 include_recipe '../../cookbooks/ollama'

--- a/mitamae/roles/belle/goss.yaml
+++ b/mitamae/roles/belle/goss.yaml
@@ -23,6 +23,7 @@ gossfile:
   ../../cookbooks/awscli/goss.yaml: {}
   ../../cookbooks/cfn-lint/goss.yaml: {}
   ../../cookbooks/gh/goss.yaml: {}
+  ../../cookbooks/devcontainer-cli/goss.yaml: {}
   ../../cookbooks/ollama/goss.yaml: {}
   ../../cookbooks/huggingface-cli/goss.yaml: {}
   ../../cookbooks/aider/goss.yaml: {}

--- a/mitamae/roles/belle/goss.yaml
+++ b/mitamae/roles/belle/goss.yaml
@@ -23,6 +23,7 @@ gossfile:
   ../../cookbooks/awscli/goss.yaml: {}
   ../../cookbooks/cfn-lint/goss.yaml: {}
   ../../cookbooks/gh/goss.yaml: {}
+  ../../cookbooks/docker/goss.yaml: {}
   ../../cookbooks/devcontainer-cli/goss.yaml: {}
   ../../cookbooks/ollama/goss.yaml: {}
   ../../cookbooks/huggingface-cli/goss.yaml: {}

--- a/mitamae/roles/hercules/default.rb
+++ b/mitamae/roles/hercules/default.rb
@@ -44,6 +44,7 @@ include_recipe '../../cookbooks/awscli'
 include_recipe '../../cookbooks/cfn-lint'
 include_recipe '../../cookbooks/gh'
 include_recipe '../../cookbooks/docker'
+include_recipe '../../cookbooks/devcontainer-cli'
 
 # AI & Coding Assistants
 include_recipe '../../cookbooks/ollama'

--- a/mitamae/roles/hercules/goss.yaml
+++ b/mitamae/roles/hercules/goss.yaml
@@ -21,6 +21,7 @@ gossfile:
   ../../cookbooks/cfn-lint/goss.yaml: {}
   ../../cookbooks/gh/goss.yaml: {}
   ../../cookbooks/docker/goss.yaml: {}
+  ../../cookbooks/devcontainer-cli/goss.yaml: {}
   ../../cookbooks/ollama/goss.yaml: {}
   ../../cookbooks/huggingface-cli/goss.yaml: {}
   ../../cookbooks/aider/goss.yaml: {}

--- a/mitamae/roles/pc137/default.rb
+++ b/mitamae/roles/pc137/default.rb
@@ -44,6 +44,7 @@ include_recipe '../../cookbooks/google-cloud-sdk'
 include_recipe '../../cookbooks/cfn-lint'
 include_recipe '../../cookbooks/gh'
 include_recipe '../../cookbooks/docker'
+include_recipe '../../cookbooks/devcontainer-cli'
 
 # AI & Coding Assistants
 include_recipe '../../cookbooks/ollama'

--- a/mitamae/roles/pc137/goss.yaml
+++ b/mitamae/roles/pc137/goss.yaml
@@ -21,6 +21,7 @@ gossfile:
   ../../cookbooks/cfn-lint/goss.yaml: {}
   ../../cookbooks/gh/goss.yaml: {}
   ../../cookbooks/docker/goss.yaml: {}
+  ../../cookbooks/devcontainer-cli/goss.yaml: {}
   ../../cookbooks/ollama/goss.yaml: {}
   ../../cookbooks/huggingface-cli/goss.yaml: {}
   ../../cookbooks/aider/goss.yaml: {}


### PR DESCRIPTION
## Summary

Add the [devcontainer CLI](https://github.com/devcontainers/cli) to the requested roles and give `belle` a container runtime.

- New `devcontainer-cli` cookbook installs `@devcontainers/cli` (binary `devcontainer`) via `npm_global_package`. No maintained Homebrew/apt formula exists, so npm is the cross-platform path on both macOS and Debian, matching the repo's convention for Node CLIs.
- Assigned to `hercules`, `belle`, `pc137`, and `bamboo`. `pine` inherits it through `bamboo`, so it is not listed explicitly (avoids a redundant include).
- Added `docker` to `belle`, which previously had no container runtime — the devcontainer CLI needs one to start containers.

## Commits

- `feat(devcontainer-cli): add cookbook and assign to roles`
- `feat(belle): add docker`

## Validation

- `bundle exec rubocop` passes on the new cookbook and all edited roles (no offenses).
- Each cookbook ships a `goss.yaml` (`devcontainer --version` command check), registered in every target role's `goss.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)