### PR TITLE
feat(roles): add imagemagick to bamboo and pc137

### DIFF
--- a/mitamae/roles/bamboo/default.rb
+++ b/mitamae/roles/bamboo/default.rb
@@ -40,6 +40,7 @@ include_recipe '../../cookbooks/gemini-cli'
 include_recipe '../../cookbooks/opencode'
 
 # Data & Document Processing
+include_recipe '../../cookbooks/imagemagick'
 include_recipe '../../cookbooks/sqlite'
 include_recipe '../../cookbooks/mysql-client'
 

--- a/mitamae/roles/bamboo/goss.yaml
+++ b/mitamae/roles/bamboo/goss.yaml
@@ -16,6 +16,7 @@ gossfile:
   ../../cookbooks/claude-code/goss.yaml: {}
   ../../cookbooks/gemini-cli/goss.yaml: {}
   ../../cookbooks/opencode/goss.yaml: {}
+  ../../cookbooks/imagemagick/goss.yaml: {}
   ../../cookbooks/sqlite/goss.yaml: {}
   ../../cookbooks/mysql-client/goss.yaml: {}
   ../../cookbooks/llvm/goss.yaml: {}

--- a/mitamae/roles/pc137/default.rb
+++ b/mitamae/roles/pc137/default.rb
@@ -68,6 +68,9 @@ include_recipe '../../cookbooks/kotlin-lsp'
 include_recipe '../../cookbooks/cloc'
 include_recipe '../../cookbooks/goss'
 
+# Data & Document Processing
+include_recipe '../../cookbooks/imagemagick'
+
 # macOS GUI
 include_recipe '../../cookbooks/feature_macos_fonts'
 include_recipe '../../cookbooks/feature_macos_media'

--- a/mitamae/roles/pc137/goss.yaml
+++ b/mitamae/roles/pc137/goss.yaml
@@ -38,3 +38,4 @@ gossfile:
   ../../cookbooks/lua-language-server/goss.yaml: {}
   ../../cookbooks/kotlin-lsp/goss.yaml: {}
   ../../cookbooks/cloc/goss.yaml: {}
+  ../../cookbooks/imagemagick/goss.yaml: {}

--- a/mitamae/roles/pine/default.rb
+++ b/mitamae/roles/pine/default.rb
@@ -40,7 +40,6 @@ include_recipe '../../cookbooks/cloc'
 
 # Data & Document Processing
 include_recipe '../../cookbooks/ffmpeg'
-include_recipe '../../cookbooks/imagemagick'
 include_recipe '../../cookbooks/pandoc'
 
 # System Utilities

--- a/mitamae/roles/pine/goss.yaml
+++ b/mitamae/roles/pine/goss.yaml
@@ -13,7 +13,6 @@ gossfile:
   ../../cookbooks/ccls/goss.yaml: {}
   ../../cookbooks/cloc/goss.yaml: {}
   ../../cookbooks/ffmpeg/goss.yaml: {}
-  ../../cookbooks/imagemagick/goss.yaml: {}
   ../../cookbooks/pandoc/goss.yaml: {}
   ../../cookbooks/asciinema/goss.yaml: {}
   ../../cookbooks/arduino-cli/goss.yaml: {}


### PR DESCRIPTION
## Summary

Assigns the existing `imagemagick` cookbook to the roles that were missing it, per request to cover `hercules`, `pc137`, `belle`, `bamboo` and the roles above them.

The `imagemagick` cookbook (and its goss) already existed and was already wired into `hercules`, `belle`, `palm`, and `pine`. Only `bamboo` and `pc137` were missing it.

## Changes

- **bamboo**: add `imagemagick` recipe + goss (Data & Document Processing). This propagates to `pine` via inheritance.
- **pine**: drop the now-redundant explicit `imagemagick` include + goss (inherited from `bamboo`) to avoid a duplicate recipe.
- **pc137**: add `imagemagick` recipe + goss under a new Data & Document Processing section.

## Verification

- `cd mitamae && bundle exec rubocop` — no offenses on the edited role files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)