### PR TITLE
Fix hercules role variant and add CI guard for role/variant mismatch

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,3 +32,26 @@ jobs:
           scandir: '.'
           additional_files: 'mitamae/bin/setup'
           ignore_names: '.zshrc entrypoint.sh'
+
+  role-variant:
+    name: Role variant matches role name
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check that each role's variant equals its directory name
+        run: |
+          status=0
+          for dir in mitamae/roles/*/; do
+            role="$(basename "$dir")"
+            file="${dir}default.rb"
+            [ -f "$file" ] || continue
+            variant="$(sed -nE "s/^[[:space:]]*variant:[[:space:]]*'([^']*)'.*/\1/p" "$file")"
+            if [ -z "$variant" ]; then
+              echo "::error file=$file::no 'variant:' found"
+              status=1
+            elif [ "$variant" != "$role" ]; then
+              echo "::error file=$file::variant '$variant' does not match role name '$role'"
+              status=1
+            fi
+          done
+          exit $status

--- a/mitamae/roles/hercules/default.rb
+++ b/mitamae/roles/hercules/default.rb
@@ -1,5 +1,5 @@
 node.reverse_merge!(
-  variant: 'belle',
+  variant: 'hercules',
   is_container: false,
 
   editor_features: {


### PR DESCRIPTION
The hercules role had variant: 'belle' carried over from a copy of the
belle role. The variant value affects template generation and other
variant-keyed behavior, so it must match the role name.

Add a lint job that verifies every role's variant equals its directory
name to prevent this class of copy-paste regression.