### PR TITLE
fix(tmux): load continuum options before running tpm

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -44,12 +44,14 @@ set -g @plugin 'tmux-plugins/tmux-resurrect'
 # Save session automaticlly
 set -g @plugin 'tmux-plugins/tmux-continuum'
 
-run '~/.config/tmux/plugins/tpm/tpm'
-
-
-# auto start terminal
+# auto start terminal on boot
 set -g @continuum-boot 'on'
-set -g @continuum-boot-options 'iterm'
 
 # auto restore tmux
 set -g @continuum-restore 'on'
+
+# Initialize TMUX plugin manager.
+# Keep this as the very last line: tpm sources each plugin at this point, and
+# tmux-continuum reads the @continuum-* options above when it loads. Setting
+# them after this line would leave auto-restore disabled.
+run '~/.config/tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary

Fixes the tmux-continuum configuration so auto-restore actually arms, and removes an option that is inconsistent with the alacritty setup.

### Problems
1. **continuum options were set *after* `run tpm`** (`tmux.conf:47` vs `51-55`). tpm sources each plugin at the `run` line, and tmux-continuum reads `@continuum-boot` / `@continuum-restore` *at load time* to install its save/restore hook. Setting them afterward leaves the plugin initialized with those options effectively off, so **auto-restore silently never arms.**
2. **`@continuum-boot-options 'iterm'`** is macOS/iTerm2-only and inconsistent with the alacritty setup.

### Changes
- Move `@continuum-boot` / `@continuum-restore` *before* the `run '.../tpm'` line.
- Keep `run '.../tpm'` as the very last line, with a comment explaining why.
- Remove `@continuum-boot-options 'iterm'`.

https://claude.ai/code/session_01MVHB4KHDRnDT7HKMhLDmc3

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVHB4KHDRnDT7HKMhLDmc3)_