### PR TITLE
fix(zsh): persist command history to a mountable directory

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   },
   "initializeCommand": "mkdir -p ${localEnv:HOME}/.ssh",
   "mounts": [
-    "source=dotfiles-zsh-history,target=/home/ubuntu/.zsh_history,type=volume",
+    "source=dotfiles-zsh-history,target=/home/ubuntu/.local/share/zsh,type=volume",
     "source=${localEnv:HOME}/.ssh,target=/home/ubuntu/.ssh,type=bind,consistency=cached,readonly=true",
     "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
   ],

--- a/mitamae/cookbooks/zsh/files/.zshrc
+++ b/mitamae/cookbooks/zsh/files/.zshrc
@@ -5,6 +5,20 @@
 autoload -U compinit
 compinit
 
+# Command history persistence.
+# zsh does NOT save history to a file unless both HISTFILE and SAVEHIST are set.
+# Use an XDG-style data location so it can be mounted as a directory in containers
+# (a single dotfile target turns into a directory under volume/bind mounts).
+HISTFILE="$HOME/.local/share/zsh/history"
+HISTSIZE=100000
+SAVEHIST=100000
+mkdir -p "${HISTFILE:h}"      # zsh won't create the parent dir on its own
+setopt SHARE_HISTORY          # read/write history across concurrent sessions
+setopt EXTENDED_HISTORY       # record command start time and duration
+setopt HIST_IGNORE_ALL_DUPS   # drop older duplicates of a command
+setopt HIST_IGNORE_SPACE      # skip commands that start with a space
+setopt HIST_REDUCE_BLANKS     # collapse superfluous whitespace before saving
+
 # If you have device-specific settings, create ~/.zshrc_specific and write them there
 if  [ -f ~/.zshrc_specific ]; then
   source ~/.zshrc_specific


### PR DESCRIPTION
## Summary

zsh command history was never persisted. This PR addresses a review finding that the history persistence setup was a no-op.

### Findings (validity assessment)

1. **HISTFILE/SAVEHIST unset** — Valid. Neither `.zshrc`, `.zshenv`, nor the shared `.shell-env.sh` set `HISTFILE`/`SAVEHIST`, so zsh never saved history to a file.
2. **devcontainer volume mounted at a file path** — Valid. The named volume targeted `~/.zsh_history`, but a volume target becomes a *directory*, so this was a no-op (and would shadow any future history file).
3. **lxc/README inconsistency** — Partially valid. The LXC example already mounts the `~/.local/share/zsh` directory, but with no `HISTFILE` set it was also a no-op. It now aligns with the fix.

### Changes

- `.zshrc`: set `HISTFILE="$HOME/.local/share/zsh/history"`, `HISTSIZE`/`SAVEHIST`, and `share/extended/ignore-dups` history options. `mkdir -p "${HISTFILE:h}"` ensures the parent dir exists (zsh won't create it).
- `.devcontainer/devcontainer.json`: point the `dotfiles-zsh-history` volume at the `~/.local/share/zsh` directory, matching the LXC README's persistent-volume example.

### Note (out of scope)

devcontainer named volumes can be root-owned on first mount, which may block writes by the `ubuntu` user. This is a pre-existing devcontainer caveat; happy to follow up with a `postCreateCommand` chown or a bind-mount if it bites in practice.

https://claude.ai/code/session_01TGaFL9p5YsdLe4GEs84MTd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGaFL9p5YsdLe4GEs84MTd)_