### PR TITLE
Fix non-idempotent installs in kotlin, ocaml, nodenv cookbooks

### DIFF
--- a/mitamae/cookbooks/kotlin/default.rb
+++ b/mitamae/cookbooks/kotlin/default.rb
@@ -4,9 +4,13 @@ elsif %w[ubuntu debian].include?(node[:platform])
   include_recipe '../sdkman'
   include_recipe '../java'
 
+  home = ENV['HOME']
+
   execute 'Install Kotlin via sdkman' do
-    home = ENV['HOME']
     command "bash -c 'source #{home}/.sdkman/bin/sdkman-init.sh && sdk install kotlin'"
-    not_if 'command -v kotlin'
+    # sdkman installs into ~/.sdkman/candidates which is not on PATH during the
+    # mitamae run, so `command -v kotlin` would never short-circuit. Test the
+    # installed binary directly so the install only runs once.
+    not_if "test -x #{home}/.sdkman/candidates/kotlin/current/bin/kotlin"
   end
 end

--- a/mitamae/cookbooks/nodenv/default.rb
+++ b/mitamae/cookbooks/nodenv/default.rb
@@ -1,29 +1,20 @@
 global_nodejs_version = '24.14.0'
 
+home = ENV['HOME']
+nodenv_root = "#{home}/.nodenv"
+
+# Ensure nodenv binary + shims are in PATH for subsequent recipes in this run
+[
+  "#{nodenv_root}/shims",
+  "#{nodenv_root}/bin"
+].each do |dir|
+  ENV['PATH'] = "#{dir}:#{ENV['PATH']}" unless ENV['PATH'].include?(dir)
+end
+
 if node[:platform] == 'darwin'
   package 'nodenv'
   package 'node-build'
-
-  execute 'Install and set global node version (macOS)' do
-    command <<-EOS
-      eval "$(nodenv init -)"
-      nodenv install #{global_nodejs_version} -s
-      nodenv global #{global_nodejs_version}
-    EOS
-    not_if "nodenv versions | grep -q '#{global_nodejs_version}'"
-  end
 elsif %w[ubuntu debian].include?(node[:platform])
-  home = ENV['HOME']
-  nodenv_root = "#{home}/.nodenv"
-
-  # Ensure nodenv shims are in PATH for subsequent recipes in this mitamae run
-  [
-    "#{nodenv_root}/shims",
-    "#{nodenv_root}/bin"
-  ].each do |dir|
-    ENV['PATH'] = "#{dir}:#{ENV['PATH']}" unless ENV['PATH'].include?(dir)
-  end
-
   execute 'Install nodenv via git' do
     command "git clone https://github.com/nodenv/nodenv.git #{nodenv_root}"
     not_if "test -d #{nodenv_root}"
@@ -37,14 +28,23 @@ elsif %w[ubuntu debian].include?(node[:platform])
     command "git clone https://github.com/nodenv/node-build.git #{nodenv_root}/plugins/node-build"
     not_if "test -d #{nodenv_root}/plugins/node-build"
   end
+end
 
-  # Install and set global node version
-  execute 'Install and set global node version' do
-    command <<-EOS
-      eval "$(nodenv init -)"
-      nodenv install #{global_nodejs_version} -s
-      nodenv global #{global_nodejs_version}
-    EOS
-    not_if "nodenv versions | grep -q '#{global_nodejs_version}'"
-  end
+# Install and set the global Node version as two separate resources so a
+# half-configured environment (version installed but global unset) is repaired
+# on a subsequent run. Mirrors ruby/default.rb.
+execute "Install Node #{global_nodejs_version} via nodenv" do
+  command <<-EOS
+    eval "$(nodenv init -)"
+    nodenv install #{global_nodejs_version} -s
+  EOS
+  not_if "test -x #{nodenv_root}/versions/#{global_nodejs_version}/bin/node"
+end
+
+execute "Set nodenv global to #{global_nodejs_version}" do
+  command <<-EOS
+    eval "$(nodenv init -)"
+    nodenv global #{global_nodejs_version}
+  EOS
+  not_if "test \"$(nodenv global)\" = '#{global_nodejs_version}'"
 end

--- a/mitamae/cookbooks/ocaml/default.rb
+++ b/mitamae/cookbooks/ocaml/default.rb
@@ -27,5 +27,9 @@ end
 
 execute 'Install ocaml-lsp-server via opam' do
   command 'opam install -y ocaml-lsp-server'
-  not_if 'command -v ocamllsp'
+  # opam installs into the switch's bin (~/.opam/default/bin) which is not on
+  # PATH during the mitamae run, so `command -v ocamllsp` would never
+  # short-circuit. Test the installed binary directly so the install only
+  # runs once.
+  not_if "test -x #{ENV['HOME']}/.opam/default/bin/ocamllsp"
 end


### PR DESCRIPTION
## 背景

 `not_if` ガードが PATH 上のコマンド解決に依存していたが、対象バイナリが mitamae 実行中の PATH 外にあるため、ガードが効かず毎回インストールが走っていたcookbookがあったので、修正。

## 変更内容

- **kotlin** (`cookbooks/kotlin/default.rb`): sdkman は `~/.sdkman/candidates` 配下にインストールし PATH 外。`command -v kotlin` は常に false になり毎回 `sdk install` が走っていた → `test -x ~/.sdkman/candidates/kotlin/current/bin/kotlin` に変更。
- **ocaml** (`cookbooks/ocaml/default.rb`): opam は switch の bin (`~/.opam/default/bin`) にインストールし PATH 外。`command -v ocamllsp` が常に false → `test -x ~/.opam/default/bin/ocamllsp` に変更。
- **nodenv** (`cookbooks/nodenv/default.rb`): install と global 設定が単一リソースに同居し、ガードが `nodenv versions` のみだったため「version は存在するが global 未設定」の状態を修復できなかった → `ruby/default.rb` と同じく install / global を別リソースに分割。指摘は darwin 側 (L7-14) だったが、Linux 側 (L42-49) にも同じ欠陥があったため両プラットフォームを修正。

## 検証

- `bundle exec rubocop`: 100 files inspected, no offenses detected
- 初回プロビジョニング時の挙動は不変（インストールは従来どおり実行される）ため、goss 検証への影響なし。


---
_Generated by [Claude Code](https://claude.ai/code/session_01LPSshHbjCggVF2Q9Sf95Ja)_