### PR TITLE
feat(git): add modern config defaults

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -1,5 +1,30 @@
 [user]
 	name = Yusei Ito
 	email = me@yuseiito.com
-	
-	
+
+[init]
+	defaultBranch = main
+
+[push]
+	autoSetupRemote = true
+
+[pull]
+	rebase = true
+
+[fetch]
+	prune = true
+
+[merge]
+	conflictstyle = zdiff3
+
+[diff]
+	algorithm = histogram
+
+[commit]
+	verbose = true
+
+[rerere]
+	enabled = true
+
+[branch]
+	sort = -committerdate


### PR DESCRIPTION
## 概要

`.config/git/config` は `[user]` の name/email のみで、git 本体が素のままだった。
近年広く推奨されるモダンデフォルトを追加する。`rules/git.md` で示している rebase 運用・細かいコミット粒度・fixup/autosquash 方針と git 本体の設定を整合させる狙い。

## 追加した設定

| 設定 | 意味 |
| --- | --- |
| `init.defaultBranch=main` | `git init` 時の初期ブランチ名を `main` に |
| `push.autoSetupRemote=true` | 新規ブランチの初 push で upstream を自動設定 |
| `pull.rebase=true` | `git pull` を merge ではなく rebase で実行 |
| `fetch.prune=true` | fetch 時にリモートで消えた追跡参照を自動削除 |
| `merge.conflictstyle=zdiff3` | コンフリクト表示に共通祖先 (base) を併記 |
| `diff.algorithm=histogram` | コード移動・インデント変更で読みやすい diff |
| `commit.verbose=true` | コミットメッセージ編集時に diff を表示 |
| `rerere.enabled=true` | 解決済みコンフリクトを記録・自動再適用 (rebase 反復で有効) |
| `branch.sort=-committerdate` | `git branch` を最終コミット日時の降順で表示 |

## 互換性メモ

- `zdiff3` は Git 2.35+、`push.autoSetupRemote` は 2.37+ が必要。macOS (Homebrew) / Debian の新しめの git は満たす。
- 古い Debian stable の git では `zdiff3` が無効値となり `diff3` 相当にフォールバックする点に留意。


---
_Generated by [Claude Code](https://claude.ai/code/session_013MGRNh4Kk8MM15vg4aXJCn)_