### PR TITLE
test(goss): verify git-commit-claude and claude-tmux-notify symlinks

### DIFF
--- a/mitamae/cookbooks/claude-code/goss.yaml
+++ b/mitamae/cookbooks/claude-code/goss.yaml
@@ -9,6 +9,9 @@ file:
   "{{.Env.HOME}}/.claude/statusline-command.sh":
     exists: true
     filetype: symlink
+  "{{.Env.HOME}}/.claude/claude-tmux-notify":
+    exists: true
+    filetype: symlink
   "{{.Env.HOME}}/.claude/skills":
     exists: true
     filetype: symlink

--- a/mitamae/roles/belle/goss.yaml
+++ b/mitamae/roles/belle/goss.yaml
@@ -29,6 +29,7 @@ gossfile:
   ../../cookbooks/huggingface-cli/goss.yaml: {}
   ../../cookbooks/aider/goss.yaml: {}
   ../../cookbooks/claude-code/goss.yaml: {}
+  ../../cookbooks/git-commit-claude/goss.yaml: {}
   ../../cookbooks/gemini-cli/goss.yaml: {}
   ../../cookbooks/opencode/goss.yaml: {}
   ../../cookbooks/kotlin/goss.yaml: {}

--- a/mitamae/roles/hercules/goss.yaml
+++ b/mitamae/roles/hercules/goss.yaml
@@ -26,6 +26,7 @@ gossfile:
   ../../cookbooks/huggingface-cli/goss.yaml: {}
   ../../cookbooks/aider/goss.yaml: {}
   ../../cookbooks/claude-code/goss.yaml: {}
+  ../../cookbooks/git-commit-claude/goss.yaml: {}
   ../../cookbooks/gemini-cli/goss.yaml: {}
   ../../cookbooks/opencode/goss.yaml: {}
   ../../cookbooks/ocaml/goss.yaml: {}

--- a/mitamae/roles/pc137/goss.yaml
+++ b/mitamae/roles/pc137/goss.yaml
@@ -26,6 +26,7 @@ gossfile:
   ../../cookbooks/huggingface-cli/goss.yaml: {}
   ../../cookbooks/aider/goss.yaml: {}
   ../../cookbooks/claude-code/goss.yaml: {}
+  ../../cookbooks/git-commit-claude/goss.yaml: {}
   ../../cookbooks/gemini-cli/goss.yaml: {}
   ../../cookbooks/opencode/goss.yaml: {}
   ../../cookbooks/corretto21/goss.yaml: {}

--- a/mitamae/roles/pine/goss.yaml
+++ b/mitamae/roles/pine/goss.yaml
@@ -7,6 +7,7 @@ gossfile:
   ../../cookbooks/nikto/goss.yaml: {}
   ../../cookbooks/cfn-lint/goss.yaml: {}
   ../../cookbooks/ollama/goss.yaml: {}
+  ../../cookbooks/git-commit-claude/goss.yaml: {}
   ../../cookbooks/sdkman/goss.yaml: {}
   ../../cookbooks/kotlin/goss.yaml: {}
   ../../cookbooks/cmake/goss.yaml: {}


### PR DESCRIPTION
## Summary

レビュー指摘を検証し、2 点とも妥当だったため修正しました。

### 指摘1: `git-commit-claude` の gossfile 未参照

`git-commit-claude` cookbook は `goss.yaml` を持ち、`belle` / `hercules` / `pc137` / `pine` の 4 ロールで `include_recipe` されているにもかかわらず、どのロールの `goss.yaml` からも参照されておらず、symlink (`git-commit-claude`, `git-ccc`) が一切検証されていませんでした。

→ 4 ロールの `goss.yaml` に `../../cookbooks/git-commit-claude/goss.yaml` を追加（cookbook の include 順に合わせて配置）。

### 指摘2: `claude-tmux-notify` が未検証

`claude-code` cookbook の recipe は 6 エントリ（`settings.json`, `statusline-command.sh`, `skills`, `claude-tmux-notify`, `CLAUDE.md`, `rules`）を `~/.claude` 配下に symlink しますが、`goss.yaml` は `claude-tmux-notify` を除く 5 つしか検証していませんでした。

→ 同じくスクリプトである `statusline-command.sh` と同様に `claude-tmux-notify` の symlink チェックを追加。

## Test plan

- [ ] CI の goss validation が通ること

https://claude.ai/code/session_01YHJ1DymoAWuqzB9wMbft8h

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHJ1DymoAWuqzB9wMbft8h)_