### PR TITLE
Pin GitHub Action digests via Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended",
     "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
     ":gitSignOff"
   ],
   "labels": ["dependencies"],


### PR DESCRIPTION
## 背景/ 課題

- 全 workflow の action が**可変タグ参照**(`docker/build-push-action@v7`, `actions/checkout@v6`, `docker/login-action@v4`, `ruby/setup-ruby@v1`, `devcontainers/ci@v0.3` 等)
- `renovate.json` の `github-actions` グループが **`automerge: true`**

このため、上流のタグが悪意あるコミットへ移動された場合(タグ移動攻撃)、その更新が自動マージされうる。

## 修正

`renovate.json` の `extends` に [`helpers:pinGitHubActionDigests`](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests) preset を追加。

これにより Renovate が action 参照を**不変の commit SHA**(`@<sha> # vX` 形式でバージョンコメント付き)に pin しつつ、以後の digest 更新で**自動追従**します。SHA pin と自動追従が両立し、タグ移動攻撃の複合リスクを解消します(OpenSSF Scorecard / StepSecurity が推奨するベストプラクティス)。

```diff
   "extends": [
     "config:recommended",
     "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
     ":gitSignOff"
   ],
```

preset 追加後、Renovate が既存 action を SHA へ pin する PR を起票します。

https://claude.ai/code/session_0115wabbBc22gzdG3DgY5cYP

---
_Generated by [Claude Code](https://claude.ai/code/session_0115wabbBc22gzdG3DgY5cYP)_