### PR TITLE
ci: install oras via setup-oras action with checksum verification

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,11 +126,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y debootstrap squashfs-tools xz-utils systemd-container rsync
-          # Install oras
-          ORAS_VERSION="1.2.0"
-          curl -sLO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
-          sudo tar -xzf "oras_${ORAS_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin oras
-          rm "oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+
+      - name: Set up oras
+        uses: oras-project/setup-oras@v2
+        with:
+          version: 1.2.0
 
       - name: Log in to the Container registry
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary

Addresses a review comment on the LXC build job in `.github/workflows/build.yaml`.

Previously oras was downloaded via `curl` from the GitHub releases page **without any checksum verification** (lines 130-133), which is a supply-chain risk — a compromised or corrupted download would be executed unverified.

This replaces the manual download with the official [`oras-project/setup-oras`](https://github.com/oras-project/setup-oras) action, which verifies the binary checksum during installation.

## Changes

- Drop the inline `curl`/`tar` download of the oras binary from the *Install build dependencies* step.
- Add a dedicated *Set up oras* step using `oras-project/setup-oras@v2`, pinned to oras version `1.2.0` (unchanged from before).

## Notes

- `setup-oras@v2` is the latest major release and verifies download checksums (checksum verification was introduced in v1.1.0).
- Action ref pinned by tag (`@v2`) to match the existing convention in this workflow.

https://claude.ai/code/session_01TBYEER5cu3pb2EcmQbecri

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBYEER5cu3pb2EcmQbecri)_