### PR TITLE
fix(nvim): address Neovim 0.11 deprecations and keymap collisions

### DIFF
--- a/.config/nvim/lua/key.lua
+++ b/.config/nvim/lua/key.lua
@@ -12,13 +12,14 @@ vim.keymap.set('n', ']B', '<cmd>blast<CR>', { silent = true, desc = "Go to last 
 
 -- Tab operations
 vim.cmd([[cnoreabbrev tn tabnew]])
--- Use Tab key to move between tabs
--- http://blog.remora.cx/2012/09/use-tabpage.html
-vim.keymap.set('n', '<S-Tab>', 'gt')
-vim.keymap.set('n', '<Tab><Tab>', 'gT')
+-- Avoid using <Tab> as a mapping prefix: in a terminal <Tab> and <C-i> share
+-- the same keycode, so prefixing with <Tab> shadows <C-i> (jumplist forward)
+-- behind a timeoutlen wait. Use bracket pairs, consistent with [b/]b above.
+vim.keymap.set('n', '[t', 'gT', { silent = true, desc = "Go to previous tab" })
+vim.keymap.set('n', ']t', 'gt', { silent = true, desc = "Go to next tab" })
 
 for i = 1, 9, 1 do
-  vim.keymap.set('n', '<Tab>' .. i, i .. 'gt', { desc = string.format("Jump to %d-th tab.", i) })
+  vim.keymap.set('n', '<leader>' .. i, i .. 'gt', { desc = string.format("Jump to %d-th tab.", i) })
 end
 
 vim.keymap.set('t', '<C-q>', '<C-\\><C-n>', { desc = 'Exit terminal mode' })

--- a/.config/nvim/lua/lsp/lsp.lua
+++ b/.config/nvim/lua/lsp/lsp.lua
@@ -10,7 +10,10 @@ vim.api.nvim_create_user_command("Format", fn_format, { nargs = 0 })
 
 vim.keymap.set('n', 'K',  '<cmd>lua vim.lsp.buf.hover()<CR>')
 vim.keymap.set('n', 'gf', '<cmd>lua vim.lsp.buf.format()<CR>')
-vim.keymap.set('n', 'gr', '<cmd>lua vim.lsp.buf.references()<CR>')
+-- `gr` is intentionally left unmapped: Neovim 0.11 ships built-in LSP mappings
+-- under the `gr` prefix (grr/grn/gra/gri/grt). Mapping `gr` directly would
+-- shadow them and force a `timeoutlen` wait. Use the built-in `grr` for
+-- references instead.
 vim.keymap.set('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>')
 vim.keymap.set('n', 'gD', '<cmd>lua vim.lsp.buf.declaration()<CR>')
 vim.keymap.set('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>')
@@ -18,5 +21,8 @@ vim.keymap.set('n', 'gt', '<cmd>lua vim.lsp.buf.type_definition()<CR>')
 vim.keymap.set('n', 'gn', '<cmd>lua vim.lsp.buf.rename()<CR>')
 vim.keymap.set('n', 'ga', '<cmd>lua vim.lsp.buf.code_action()<CR>')
 vim.keymap.set('n', 'ge', '<cmd>lua vim.diagnostic.open_float()<CR>')
-vim.keymap.set('n', 'g]', '<cmd>lua vim.diagnostic.goto_next()<CR>')
-vim.keymap.set('n', 'g[', '<cmd>lua vim.diagnostic.goto_prev()<CR>')
+-- `vim.diagnostic.goto_next/goto_prev` are deprecated since Neovim 0.11.
+-- Use `vim.diagnostic.jump({ count = ... })`; `float = true` keeps the
+-- previous behaviour of showing the diagnostic in a floating window.
+vim.keymap.set('n', 'g]', function() vim.diagnostic.jump({ count = 1, float = true }) end)
+vim.keymap.set('n', 'g[', function() vim.diagnostic.jump({ count = -1, float = true }) end)

--- a/.config/nvim/lua/plugins/lsp.lua
+++ b/.config/nvim/lua/plugins/lsp.lua
@@ -16,7 +16,9 @@ return {
     "Saghen/blink.cmp",
     enabled = features.lsp,
     version = "1.*",
-    event = "InsertEnter",
+    -- No lazy-load event: blink.cmp is a dependency of nvim-lspconfig (which is
+    -- `lazy = false`) and its capabilities are required in that plugin's
+    -- config, so it always loads at startup. An `event` here would be a no-op.
     opts = {
       keymap = {
         preset = "default",

--- a/.config/nvim/lua/plugins/toggleterm.lua
+++ b/.config/nvim/lua/plugins/toggleterm.lua
@@ -5,21 +5,25 @@ return {
   enabled = features.basic_amenities,
   version = "*",
   cmd = { "ToggleTerm", "ToggleTermToggleAll" },
-  keys = { "<leader>g" },
+  -- Only register the lazygit binding on roles that actually install lazygit;
+  -- otherwise <leader>g would launch a missing binary.
+  keys = features.lazygit and { "<leader>g" } or nil,
   config = function()
     require("toggleterm").setup()
 
-    local Terminal = require('toggleterm.terminal').Terminal
-    local lazygit  = Terminal:new({
-      cmd = "lazygit",
-      hidden = true,
-      direction = "float",
-    })
+    if features.lazygit then
+      local Terminal = require('toggleterm.terminal').Terminal
+      local lazygit  = Terminal:new({
+        cmd = "lazygit",
+        hidden = true,
+        direction = "float",
+      })
 
-    function _lazygit_toggle()
-      lazygit:toggle()
+      function _lazygit_toggle()
+        lazygit:toggle()
+      end
+
+      vim.keymap.set("n", "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", { silent = true, desc= "Open lazygit on floating window."})
     end
-
-    vim.keymap.set("n", "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", { silent = true, desc= "Open lazygit on floating window."})
   end,
 }

--- a/mitamae/cookbooks/neovim/templates/features.lua.erb
+++ b/mitamae/cookbooks/neovim/templates/features.lua.erb
@@ -6,7 +6,6 @@ M.lsp = <%= node[:editor_features][:lsp] %>
 M.lazygit = <%= node[:editor_features][:lazygit] %>
 M.ai = <%= node[:editor_features][:ai] %>
 M.rich_presence = <%= node[:editor_features][:rich_presence] %>
-M.rust_dev = <%= node[:editor_features][:rust_dev] %>
 M.basic_amenities = <%= node[:editor_features][:basic_amenities] %>
 M.prisma_dev = <%= node[:editor_features][:prisma_dev] %>
 M.render_md = <%= node[:editor_features][:render_md] %>

--- a/mitamae/roles/bamboo/default.rb
+++ b/mitamae/roles/bamboo/default.rb
@@ -5,7 +5,6 @@ node.reverse_merge!(
     lsp: true,
     basic_amenities: true,
     lazygit: true,
-    rust_dev: true,
     prisma_dev: true,
     render_md: false,
     ai: true,

--- a/mitamae/roles/belle/default.rb
+++ b/mitamae/roles/belle/default.rb
@@ -6,7 +6,6 @@ node.reverse_merge!(
     lsp: true,
     basic_amenities: true,
     lazygit: true,
-    rust_dev: true,
     prisma_dev: true,
     render_md: true,
     ai: true,

--- a/mitamae/roles/hercules/default.rb
+++ b/mitamae/roles/hercules/default.rb
@@ -6,7 +6,6 @@ node.reverse_merge!(
     lsp: true,
     basic_amenities: true,
     lazygit: true,
-    rust_dev: true,
     prisma_dev: true,
     render_md: true,
     ai: true,

--- a/mitamae/roles/palm/default.rb
+++ b/mitamae/roles/palm/default.rb
@@ -6,7 +6,6 @@ node.reverse_merge!(
     lsp: true,
     basic_amenities: true,
     lazygit: false,
-    rust_dev: true,
     prisma_dev: true,
     render_md: false,
     ai: false,

--- a/mitamae/roles/pc137/default.rb
+++ b/mitamae/roles/pc137/default.rb
@@ -6,7 +6,6 @@ node.reverse_merge!(
     lsp: true,
     basic_amenities: true,
     lazygit: true,
-    rust_dev: true,
     prisma_dev: true,
     render_md: true,
     ai: true,

--- a/mitamae/roles/pine/default.rb
+++ b/mitamae/roles/pine/default.rb
@@ -6,7 +6,6 @@ node.reverse_merge!(
     lsp: true,
     basic_amenities: true,
     lazygit: true,
-    rust_dev: true,
     prisma_dev: true,
     render_md: true,
     ai: true,

--- a/mitamae/roles/plum/default.rb
+++ b/mitamae/roles/plum/default.rb
@@ -6,7 +6,6 @@ node.reverse_merge!(
     lsp: false,
     basic_amenities: false,
     lazygit: false,
-    rust_dev: false,
     prisma_dev: false,
     render_md: false,
     ai: false,


### PR DESCRIPTION
## Summary

Addresses a Neovim config review covering 0.11 deprecations, keymap collisions, and dead feature flags. All five points were verified against the codebase (Neovim `0.11.6` is pinned in `mitamae/cookbooks/neovim/default.rb`) before applying fixes.

## Findings & fixes

| # | Finding | Verdict | Fix |
|---|---------|---------|-----|
| 1 | `vim.diagnostic.goto_next/goto_prev` deprecated in 0.11 | ✅ valid | Switched to `vim.diagnostic.jump({ count = ±1, float = true })` (`float = true` preserves the old floating-window behaviour) |
| 2 | Normal-mode `<Tab>` prefix shadows `<C-i>` (jumplist forward) | ✅ valid | Moved tab navigation off `<Tab>`: `[t`/`]t` for prev/next (consistent with existing `[b`/`]b`) and `<leader>N` for numbered tabs |
| 3 | Direct `gr` mapping collides with the 0.11 built-in `gr*` prefix (`grr/grn/gra/gri/grt`), causing a `timeoutlen` wait | ✅ valid | Dropped the custom `gr` mapping; references are covered by the built-in `grr` |
| 4 | Dead feature flags `features.lazygit` / `features.rust_dev` | ✅ valid | `lazygit`: now actually gates the `<leader>g` binding in `toggleterm.lua` — previously it was registered whenever `basic_amenities` was on, so `<leader>g` launched a missing binary on roles like `palm` (`lazygit: false`, no lazygit cookbook). `rust_dev`: had nothing to gate (no rust Neovim plugin), so removed from the template and all roles |
| 5 | blink.cmp `event = "InsertEnter"` is a no-op | ✅ valid | Removed it — blink.cmp is a dependency of the `lazy = false` `nvim-lspconfig` and its capabilities are used in that plugin's `config`, so it always loads at startup |

## Verification

- `cd mitamae && bundle exec rubocop` → **100 files inspected, no offenses detected**
- Confirmed `palm` was the concrete broken case for finding #4 (`basic_amenities: true`, `lazygit: false`, no lazygit cookbook included).

https://claude.ai/code/session_01WNSQvT5QN2bhk65jie1ZsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNSQvT5QN2bhk65jie1ZsP)_