### PR TITLE
Replace host Docker socket bind with rootless docker-in-docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,15 +3,27 @@
   "image": "ghcr.io/yuseiito/yuseiito-dev:bamboo-latest",
   "remoteUser": "ubuntu",
   "containerUser": "ubuntu",
+  // Keep the container user's UID stable so the rootless Docker socket path
+  // (/run/user/1000/docker.sock) referenced below stays correct.
+  "updateRemoteUserUID": false,
   "remoteEnv": {
     "DOTFILES_ROLE": "bamboo"
+  },
+  // Talk to the in-container rootless Docker daemon instead of the host
+  // daemon. See start-rootless-docker.sh for why the host socket bind mount
+  // was removed.
+  "containerEnv": {
+    "XDG_RUNTIME_DIR": "/run/user/1000",
+    "DOCKER_HOST": "unix:///run/user/1000/docker.sock"
   },
   "initializeCommand": "mkdir -p ${localEnv:HOME}/.ssh",
   "mounts": [
     "source=dotfiles-zsh-history,target=/home/ubuntu/.local/share/zsh,type=volume",
-    "source=${localEnv:HOME}/.ssh,target=/home/ubuntu/.ssh,type=bind,consistency=cached,readonly=true",
-    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+    "source=${localEnv:HOME}/.ssh,target=/home/ubuntu/.ssh,type=bind,consistency=cached,readonly=true"
   ],
+  // Start the rootless daemon after the container is up. The script no-ops if
+  // the rootless tooling is unavailable, so it never blocks startup.
+  "postStartCommand": "bash .devcontainer/start-rootless-docker.sh",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/start-rootless-docker.sh
+++ b/.devcontainer/start-rootless-docker.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Start a rootless Docker daemon inside the dev container.
+#
+# This replaces the previous `/var/run/docker.sock` bind mount, which shared
+# the host's Docker daemon with the container. Access to that socket is
+# effectively host root (a container could start a privileged container or
+# mount the host filesystem), so a container compromise escalated straight to
+# the host. A rootless daemon runs entirely inside the container's user
+# namespace, removing that escalation path.
+#
+# This script always exits 0: Docker availability must never block container
+# startup. When the rootless tooling is absent (e.g. an older base image that
+# predates docker-ce-rootless-extras), it simply no-ops.
+set -u
+
+uid="$(id -u)"
+user="$(id -un)"
+runtime_dir="/run/user/${uid}"
+sock="${runtime_dir}/docker.sock"
+
+# Already running? Nothing to do.
+if [ -S "${sock}" ]; then
+  exit 0
+fi
+
+# The rootless launcher is provided by docker-ce-rootless-extras. If it is not
+# installed, leave Docker unconfigured rather than failing startup.
+if ! command -v dockerd-rootless.sh >/dev/null 2>&1; then
+  echo "rootless docker: dockerd-rootless.sh not found, skipping startup" >&2
+  exit 0
+fi
+
+# Ensure subordinate UID/GID ranges exist for the current user; rootless mode
+# needs them to map container UIDs into the user namespace.
+if ! grep -q "^${user}:" /etc/subuid 2>/dev/null; then
+  echo "${user}:100000:65536" | sudo tee -a /etc/subuid >/dev/null
+fi
+if ! grep -q "^${user}:" /etc/subgid 2>/dev/null; then
+  echo "${user}:100000:65536" | sudo tee -a /etc/subgid >/dev/null
+fi
+
+# Ensure the XDG runtime directory exists and is owned by the user.
+if [ ! -d "${runtime_dir}" ]; then
+  sudo install -d -m 0700 -o "${uid}" -g "${uid}" "${runtime_dir}"
+fi
+export XDG_RUNTIME_DIR="${runtime_dir}"
+
+# Launch the daemon in the background. It listens on
+# unix://${XDG_RUNTIME_DIR}/docker.sock, which DOCKER_HOST points to.
+nohup dockerd-rootless.sh >"${runtime_dir}/dockerd.log" 2>&1 &
+
+exit 0

--- a/mitamae/cookbooks/docker/default.rb
+++ b/mitamae/cookbooks/docker/default.rb
@@ -31,8 +31,25 @@ elsif %w[ubuntu debian].include?(node[:platform])
     not_if 'test -f /etc/apt/sources.list.d/docker.list'
   end
 
-  # Install Docker Engine and plugins
-  %w[docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin].each do |pkg|
+  # Install Docker Engine and plugins. docker-ce-rootless-extras ships the
+  # dockerd-rootless.sh launcher used to run the daemon without root.
+  %w[
+    docker-ce
+    docker-ce-cli
+    containerd.io
+    docker-buildx-plugin
+    docker-compose-plugin
+    docker-ce-rootless-extras
+  ].each do |pkg|
+    package pkg do
+      user 'root'
+    end
+  end
+
+  # Prerequisites for rootless Docker: user-namespace mapping (uidmap),
+  # a rootless overlay backend (fuse-overlayfs) and userspace networking
+  # (slirp4netns). dbus-user-session lets the per-user session start cleanly.
+  %w[uidmap dbus-user-session fuse-overlayfs slirp4netns].each do |pkg|
     package pkg do
       user 'root'
     end


### PR DESCRIPTION
## 背景
- devcontainerでは、`/var/run/docker.sock` を bind マウントしていた
- これは、コンテナ内プロセスがホストの Docker デーモンをフル制御できることを意味し、`--privileged` コンテナ起動やホスト FS マウント経由で **実質ホスト root へ昇格可能**な典型的エスカレーション経路。

## 対応: rootless docker-in-docker

ホスト socket の共有をやめ、コンテナの user namespace 内で動く **rootless Docker デーモン**に置き換える。これでホスト root への経路を断ちつつ Docker は引き続き利用可能。

- `mitamae/cookbooks/docker/default.rb`: Debian/Ubuntu 分岐に `docker-ce-rootless-extras` と rootless 前提パッケージ（`uidmap`, `fuse-overlayfs`, `slirp4netns`, `dbus-user-session`）を追加。
- `.devcontainer/start-rootless-docker.sh`: per-user runtime socket 上で `dockerd-rootless.sh` を起動。rootless ツール不在時は no-op で **コンテナ起動をブロックしない**。
- `.devcontainer/devcontainer.json`: host socket マウントを削除し、`DOCKER_HOST` を rootless socket に向け、UID を固定、`postStartCommand` で起動スクリプトを実行。
- `~/.ssh` の readonly bind マウントはレビュー通り維持。

## CI への影響

`test.yaml` の devcontainer ジョブは prebuild イメージ `bamboo-latest`（rootless extras 未導入）を pull するため、起動スクリプトは `dockerd-rootless.sh` 不在を検知してスキップ → 起動は成功。本 PR が main にマージされ `build.yaml` でイメージが再ビルドされると、以降の devcontainer セッションで rootless デーモンが実際に有効化される。

## 確認

- `rubocop`: 100 files inspected, no offenses
- `shellcheck` (新規スクリプト): pass

https://claude.ai/code/session_01AA3kErMVaeCYEX81JNdwXx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AA3kErMVaeCYEX81JNdwXx)_