### PR TITLE
refactor(platformio): use uv_tool_package resource on Linux

### DIFF
--- a/mitamae/cookbooks/platformio/default.rb
+++ b/mitamae/cookbooks/platformio/default.rb
@@ -1,8 +1,7 @@
 if node[:platform] == 'darwin'
   package 'platformio'
 elsif %w[ubuntu debian].include?(node[:platform])
-  execute 'Install PlatformIO via official installer' do
-    command 'uv tool install platformio'
-    not_if 'command -v pio || test -f ~/.platformio/penv/bin/pio'
+  uv_tool_package 'platformio' do
+    bin_name 'pio'
   end
 end


### PR DESCRIPTION
## Summary

The Linux branch used a raw `execute` block that:
- ran `uv tool install platformio` **without** `include_recipe` for the `uv` cookbook, creating an implicit dependency on `uv` already being installed; and
- carried the name `"Install PlatformIO via official installer"`, which does not reflect the actual `uv tool install` command.

Every other uv-based cookbook (`cfn-lint`, `pylsp`, `huggingface-cli`) uses the `uv_tool_package` custom resource, which provisions the `uv` dependency via `include_recipe` and names the execute `"uv tool install <pkg>"`.

## Changes

- Replace the raw `execute` block with `uv_tool_package 'platformio'`.
- Set `bin_name 'pio'` so the idempotency guard checks `command -v pio`, matching the `goss.yaml` smoke test (`pio --version`).

## Verification

- `bundle exec rubocop cookbooks/platformio/default.rb` → no offenses.
- Behavior is preserved: idempotent install via `uv`, validated by the existing goss check.

https://claude.ai/code/session_01X8SGgXQTsFp66RaAYCvHCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8SGgXQTsFp66RaAYCvHCT)_