### PR TITLE
perf(zsh): cache compinit dump and lazy-init nodenv/rbenv

### DIFF
--- a/mitamae/cookbooks/zsh/files/.zshrc
+++ b/mitamae/cookbooks/zsh/files/.zshrc
@@ -2,8 +2,21 @@
 
 # Auto complete (ssh,rsync,etc..)
 # NOTE: enhancd's init.sh uses compdef, so run compinit before .zshrc_specific
-autoload -U compinit
-compinit
+autoload -Uz compinit
+# Rebuild the completion dump (with the full security check) at most once a day;
+# otherwise load the cached dump directly via -C to shorten startup. The glob
+# qualifier (N.mh+24) matches a plain file modified over 24h ago, so this stays
+# portable across macOS and Linux without shelling out to stat(1). Note the glob
+# must run in a normal command context (an array assignment), not inside [[ ]],
+# where zsh does not perform filename generation. On first run the dump is absent,
+# so the -C branch is taken and compinit -C still creates it.
+zcompdump_stale=(${ZDOTDIR:-$HOME}/.zcompdump(N.mh+24))
+if (( ${#zcompdump_stale} )); then
+  compinit
+else
+  compinit -C
+fi
+unset zcompdump_stale
 
 # Command history persistence.
 # zsh does NOT save history to a file unless both HISTFILE and SAVEHIST are set.
@@ -45,14 +58,24 @@ if command -v zoxide > /dev/null 2>&1; then
 fi
 
 
-# Initialize nodenv if it's installed
+# Lazy-init nodenv: its shims are already on PATH via ~/.shell-env.sh (sourced from
+# ~/.zshenv), so `nodenv init` only adds completion and the `nodenv` shell function.
+# Defer that cost until nodenv is first invoked to keep interactive startup fast.
 if command -v nodenv > /dev/null 2>&1; then
-  eval "$(nodenv init -)"
+  nodenv() {
+    unfunction nodenv
+    eval "$(command nodenv init -)"
+    nodenv "$@"
+  }
 fi
 
-# Initialize rbenv if it's installed
+# Lazy-init rbenv (same rationale as nodenv above; shims come from ~/.shell-env.sh).
 if command -v rbenv > /dev/null 2>&1; then
-  eval "$(rbenv init - zsh)"
+  rbenv() {
+    unfunction rbenv
+    eval "$(command rbenv init - zsh)"
+    rbenv "$@"
+  }
 fi
 
 # THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!


### PR DESCRIPTION
## 概要

`.zshrc` の対話起動を高速化しました。

### 課題1: compinit にキャッシュなし
毎起動で完了 dump の再生成とセキュリティチェックが走っていました。定番の「1日1回だけ再生成、24h 以内はキャッシュ済み dump を `compinit -C` で読む」パターンを導入します。

- 24h 判定は `stat(1)` ではなく zsh の glob qualifier `(N.mh+24)` を使用し、macOS/Linux 両対応を維持。
- **注意点(検証で発覚):** glob qualifier は `[[ ]]` 内では評価されません(zsh は `[[ ]]` 内で filename generation を行わない)。実際に `[[ -n …(#qN.mh+24) ]]` 形式は全ケースで真になるバグを確認したため、配列代入(通常のコマンドコンテキスト)で glob を走らせる形に修正済み。
- 初回(dump 不在)は `-C` ブランチを通りますが、`compinit -C` が dump を生成することを実機で確認。

### 課題2: nodenv / rbenv の遅延初期化
shims は `~/.zshenv` → `~/.shell-env.sh` で既に PATH に入っているため、`nodenv/rbenv init` の残る役割は補完とシェル関数ラッパーのみです。初回呼び出しまで遅延する自己置換関数に変更しました。

## 検証

実機 zsh で以下を確認:

| ケース | compinit 判定 |
|---|---|
| dump 不在 | `-C`(初回、dump 生成される） |
| dump < 24h | `-C`(高速パス） |
| dump > 24h | full `compinit`(再生成） |

- `zsh -n` 構文チェック: OK
- 遅延初期化: 初回呼び出しで `init` が eval され実関数に置換、2回目以降は直接実行されることを確認。

なお CI の `zsh -c`(非対話)は `.zshrc` を読み込まないため、上記はローカルで検証しています。

https://claude.ai/code/session_01RuGJnGDsVNXyiY8J6AdggE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuGJnGDsVNXyiY8J6AdggE)_