### PR TITLE
Unify unsupported-platform handling via unsupported_platform! helper

### DIFF
--- a/.claude/skills/add-cookbook/SKILL.md
+++ b/.claude/skills/add-cookbook/SKILL.md
@@ -77,12 +77,25 @@ Debian installs run as root automatically. Darwin uses brew.
 
 ### `brew_cask` — macOS GUI applications
 
-Only available on macOS. Use for `.app` bundles (not CLI tools).
+Only available on macOS. Use for `.app` bundles (not CLI tools). Pair it with
+an explicit `unsupported_platform!` fallback so the cookbook fails loudly if it
+is ever reached on a non-macOS host (see "Unsupported platforms" below).
 
 ```ruby
 if node[:platform] == 'darwin'
   brew_cask 'wezterm'
+else
+  unsupported_platform! node[:platform]
 end
+```
+
+### `unsupported_platform!` — fail loudly on platforms you don't support
+
+Always terminate platform branches with this helper instead of silently
+skipping. See "Unsupported platforms" below for the full policy.
+
+```ruby
+unsupported_platform! node[:platform]
 ```
 
 ### `cargo_package` — Rust binaries
@@ -156,6 +169,8 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     not_if 'snap list | grep -q mytool'
   end
+else
+  unsupported_platform! node[:platform]
 end
 ```
 
@@ -181,6 +196,28 @@ end
 node[:platform] == 'darwin'                        # macOS
 %w[ubuntu debian].include?(node[:platform])        # Debian/Ubuntu Linux
 ```
+
+### Unsupported platforms (required)
+
+Every cookbook must handle each platform it supports explicitly and **fail
+loudly on the rest** by calling `unsupported_platform! node[:platform]`. Never
+leave a bare `if`/`elsif` without an `else`, and never write
+`... if node[:platform] == 'darwin'` as a silent guard — both hide
+role/platform misconfigurations behind a no-op.
+
+```ruby
+if node[:platform] == 'darwin'
+  package 'mytool'
+elsif %w[ubuntu debian].include?(node[:platform])
+  # ... Linux install ...
+else
+  unsupported_platform! node[:platform]
+end
+```
+
+Cookbooks built solely on `cross_platform_package`, `cargo_package`,
+`uv_tool_package`, or `npm_global_package` already embed this policy and need no
+extra branch.
 
 ### Architecture
 
@@ -212,6 +249,8 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     not_if "mytool --version 2>/dev/null | grep -q '#{mytool_version}'"
   end
+else
+  unsupported_platform! node[:platform]
 end
 ```
 

--- a/mitamae/cookbooks/README.md
+++ b/mitamae/cookbooks/README.md
@@ -8,3 +8,35 @@ Categorization is done at the role level (see [roles/](../roles/)).
 
 Many simple cross-platform package cookbooks use the `cross_platform_package`
 custom resource defined in [`lib/custom_resources.rb`](../lib/custom_resources.rb).
+
+## Handling unsupported platforms
+
+Every cookbook must explicitly handle each platform it supports and **fail
+loudly on the rest**. When a cookbook is reached on a platform it does not
+support, it must call the `unsupported_platform!` helper (defined in
+[`lib/custom_resources.rb`](../lib/custom_resources.rb)) instead of silently
+skipping installation:
+
+```ruby
+if node[:platform] == 'darwin'
+  package 'mytool'
+elsif %w[ubuntu debian].include?(node[:platform])
+  # ... Linux install ...
+else
+  unsupported_platform! node[:platform]
+end
+```
+
+Cookbooks are only ever included in roles whose platform they target, so
+reaching `unsupported_platform!` means the role/platform combination is
+misconfigured. Aborting the run surfaces that mistake immediately rather than
+leaving a half-provisioned host. Do **not** leave a bare `if`/`elsif` without
+an `else`, and do not silently `... if node[:platform] == 'darwin'` — both hide
+misconfigurations behind a no-op.
+
+The only exception is a cookbook that genuinely targets every platform via a
+catch-all branch (the package manager handles the differences). In that case
+name the supported platforms explicitly and still terminate with
+`unsupported_platform!` for anything unexpected. The `cross_platform_package`,
+`cargo_package`, `uv_tool_package`, and `npm_global_package` helpers already
+embed this policy, so cookbooks built solely on them need no extra branch.

--- a/mitamae/cookbooks/affinity/default.rb
+++ b/mitamae/cookbooks/affinity/default.rb
@@ -1,1 +1,5 @@
-brew_cask 'affinity' if node[:platform] == 'darwin'
+if node[:platform] == 'darwin'
+  brew_cask 'affinity'
+else
+  unsupported_platform! node[:platform]
+end

--- a/mitamae/cookbooks/aider/default.rb
+++ b/mitamae/cookbooks/aider/default.rb
@@ -5,4 +5,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     command 'curl -fsSL https://aider.chat/install.sh | sh'
     not_if 'command -v aider'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/alacritty/default.rb
+++ b/mitamae/cookbooks/alacritty/default.rb
@@ -10,6 +10,8 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     not_if 'snap list | grep -q alacritty'
   end
+else
+  unsupported_platform! node[:platform]
 end
 
 dotconfig 'alacritty'

--- a/mitamae/cookbooks/arduino-cli/default.rb
+++ b/mitamae/cookbooks/arduino-cli/default.rb
@@ -6,4 +6,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     not_if 'command -v arduino-cli'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/arduino-ide/default.rb
+++ b/mitamae/cookbooks/arduino-ide/default.rb
@@ -1,3 +1,3 @@
-raise "Unsupported platform: #{node[:platform]}" unless node[:platform] == 'darwin'
+unsupported_platform!(node[:platform]) unless node[:platform] == 'darwin'
 
 brew_cask 'arduino-ide'

--- a/mitamae/cookbooks/arm-none-eabi-gcc/default.rb
+++ b/mitamae/cookbooks/arm-none-eabi-gcc/default.rb
@@ -1,6 +1,5 @@
 if node[:platform] == 'darwin'
   package 'arm-none-eabi-gcc'
 else
-  Mitamae.logger.error "unsupported platform #{node[:platform]}: #{__FILE__}:#{__LINE__}"
-  exit 1
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/asciinema/default.rb
+++ b/mitamae/cookbooks/asciinema/default.rb
@@ -21,4 +21,6 @@ if %w[ubuntu debian].include?(node[:platform])
 elsif node[:platform] == 'darwin'
   package 'asciinema'
   package 'agg'
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/awscli/default.rb
+++ b/mitamae/cookbooks/awscli/default.rb
@@ -20,4 +20,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     not_if 'command -v aws'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/biome/default.rb
+++ b/mitamae/cookbooks/biome/default.rb
@@ -4,4 +4,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   npm_global_package '@biomejs/biome' do
     bin_name 'biome'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/build-essential/default.rb
+++ b/mitamae/cookbooks/build-essential/default.rb
@@ -2,4 +2,6 @@ if %w[ubuntu debian].include?(node[:platform])
   package 'build-essential' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/cfn-lint/default.rb
+++ b/mitamae/cookbooks/cfn-lint/default.rb
@@ -2,4 +2,6 @@ if node[:platform] == 'darwin'
   package 'cfn-lint'
 elsif %w[ubuntu debian].include?(node[:platform])
   uv_tool_package 'cfn-lint'
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/claude-code/default.rb
+++ b/mitamae/cookbooks/claude-code/default.rb
@@ -21,6 +21,8 @@ elsif %w[ubuntu debian].include?(node[:platform])
     command 'curl -fsSL https://claude.ai/install.sh | bash -s latest'
     not_if 'command -v claude'
   end
+else
+  unsupported_platform! node[:platform]
 end
 
 %w[settings.json statusline-command.sh skills claude-tmux-notify CLAUDE.md rules].each do |entry|

--- a/mitamae/cookbooks/cloudflared/default.rb
+++ b/mitamae/cookbooks/cloudflared/default.rb
@@ -16,7 +16,8 @@ if %w[ubuntu debian].include?(node[:platform])
     EOC
     not_if 'command -v cloudflared'
   end
-else
-  # macOS, Arch Linux
+elsif %w[darwin arch].include?(node[:platform])
   package 'cloudflared'
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/cncjs/default.rb
+++ b/mitamae/cookbooks/cncjs/default.rb
@@ -2,4 +2,6 @@ if node[:platform] == 'darwin'
   brew_cask 'cncjs'
 elsif %w[debian ubuntu].include?(node[:platform])
   npm_global_package 'cncjs'
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/corretto21/default.rb
+++ b/mitamae/cookbooks/corretto21/default.rb
@@ -14,4 +14,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'java-21-amazon-corretto-jdk' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/docker/default.rb
+++ b/mitamae/cookbooks/docker/default.rb
@@ -37,4 +37,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
       user 'root'
     end
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/fastfetch/default.rb
+++ b/mitamae/cookbooks/fastfetch/default.rb
@@ -19,4 +19,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     EOC
     not_if "fastfetch --version 2>/dev/null | grep -q '#{fastfetch_version}'"
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/feature_macos_communication/default.rb
+++ b/mitamae/cookbooks/feature_macos_communication/default.rb
@@ -10,4 +10,6 @@ if node[:platform] == 'darwin'
   casks.each do |cask|
     brew_cask cask
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/feature_macos_fonts/default.rb
+++ b/mitamae/cookbooks/feature_macos_fonts/default.rb
@@ -8,4 +8,6 @@ if node[:platform] == 'darwin'
   casks.each do |cask|
     brew_cask cask
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/feature_macos_media/default.rb
+++ b/mitamae/cookbooks/feature_macos_media/default.rb
@@ -9,4 +9,6 @@ if node[:platform] == 'darwin'
   casks.each do |cask|
     brew_cask cask
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/feature_macos_utilities/default.rb
+++ b/mitamae/cookbooks/feature_macos_utilities/default.rb
@@ -16,4 +16,6 @@ if node[:platform] == 'darwin'
   casks.each do |cask|
     brew_cask cask
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/feature_macos_writing/default.rb
+++ b/mitamae/cookbooks/feature_macos_writing/default.rb
@@ -9,4 +9,6 @@ if node[:platform] == 'darwin'
   casks.each do |cask|
     brew_cask cask
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/figma/default.rb
+++ b/mitamae/cookbooks/figma/default.rb
@@ -1,1 +1,5 @@
-brew_cask 'figma' if node[:platform] == 'darwin'
+if node[:platform] == 'darwin'
+  brew_cask 'figma'
+else
+  unsupported_platform! node[:platform]
+end

--- a/mitamae/cookbooks/firefox/default.rb
+++ b/mitamae/cookbooks/firefox/default.rb
@@ -14,4 +14,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'firefox' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/flatcam/default.rb
+++ b/mitamae/cookbooks/flatcam/default.rb
@@ -12,6 +12,5 @@ if node[:platform] == 'darwin'
     not_if 'brew list --formula tomoyanonymous/homebrew-flatcam/flatcam-evo >/dev/null 2>&1'
   end
 else
-  Mitamae.logger.error "unsupported platform #{node[:platform]}: #{__FILE__}:#{__LINE__}"
-  exit 1
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/freecad/default.rb
+++ b/mitamae/cookbooks/freecad/default.rb
@@ -4,4 +4,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'freecad' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/gemini-cli/default.rb
+++ b/mitamae/cookbooks/gemini-cli/default.rb
@@ -4,4 +4,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   npm_global_package '@google/gemini-cli' do
     bin_name 'gemini'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/gh/default.rb
+++ b/mitamae/cookbooks/gh/default.rb
@@ -17,4 +17,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'gh' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/git/default.rb
+++ b/mitamae/cookbooks/git/default.rb
@@ -2,9 +2,10 @@ if %w[ubuntu debian].include?(node[:platform])
   package 'git' do
     user 'root'
   end
-else
-  # macOS, Arch Linux
+elsif %w[darwin arch].include?(node[:platform])
   package 'git'
+else
+  unsupported_platform! node[:platform]
 end
 
 dotconfig 'git'

--- a/mitamae/cookbooks/google-chrome/default.rb
+++ b/mitamae/cookbooks/google-chrome/default.rb
@@ -13,4 +13,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'google-chrome-stable' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/google-cloud-sdk/default.rb
+++ b/mitamae/cookbooks/google-cloud-sdk/default.rb
@@ -21,4 +21,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'google-cloud-cli' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/goss/default.rb
+++ b/mitamae/cookbooks/goss/default.rb
@@ -21,4 +21,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     not_if 'command -v goss'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/homebrew/default.rb
+++ b/mitamae/cookbooks/homebrew/default.rb
@@ -3,4 +3,6 @@ if node[:platform] == 'darwin'
     command 'NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
     not_if 'command -v brew'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/huggingface-cli/default.rb
+++ b/mitamae/cookbooks/huggingface-cli/default.rb
@@ -2,4 +2,6 @@ if node[:platform] == 'darwin'
   package 'huggingface-cli'
 elsif %w[ubuntu debian].include?(node[:platform])
   uv_tool_package 'hf'
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/java/default.rb
+++ b/mitamae/cookbooks/java/default.rb
@@ -2,4 +2,6 @@ if node[:platform] == 'darwin'
   package 'temurin'
 elsif %w[ubuntu debian].include?(node[:platform])
   include_recipe '../corretto21'
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/kicad/default.rb
+++ b/mitamae/cookbooks/kicad/default.rb
@@ -4,4 +4,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'kicad' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/kotlin-lsp/default.rb
+++ b/mitamae/cookbooks/kotlin-lsp/default.rb
@@ -47,4 +47,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     force true
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/kotlin/default.rb
+++ b/mitamae/cookbooks/kotlin/default.rb
@@ -13,4 +13,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     # installed binary directly so the install only runs once.
     not_if "test -x #{home}/.sdkman/candidates/kotlin/current/bin/kotlin"
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/lazygit/default.rb
+++ b/mitamae/cookbooks/lazygit/default.rb
@@ -19,6 +19,8 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     not_if "lazygit --version 2>/dev/null | grep -q '#{lazygit_version}'"
   end
+else
+  unsupported_platform! node[:platform]
 end
 
 dotconfig 'lazygit'

--- a/mitamae/cookbooks/llvm/default.rb
+++ b/mitamae/cookbooks/llvm/default.rb
@@ -4,4 +4,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'clangd' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/lua-language-server/default.rb
+++ b/mitamae/cookbooks/lua-language-server/default.rb
@@ -30,4 +30,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     force true
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/neovim/default.rb
+++ b/mitamae/cookbooks/neovim/default.rb
@@ -36,8 +36,7 @@ when 'arch'
     user 'root'
   end
 else
-  Mitamae.logger.error "unsupported platform #{node[:platform]}: #{__FILE__}:#{__LINE__}"
-  exit 1
+  unsupported_platform! node[:platform]
 end
 
 home = ENV['HOME']

--- a/mitamae/cookbooks/nodenv/default.rb
+++ b/mitamae/cookbooks/nodenv/default.rb
@@ -28,6 +28,8 @@ elsif %w[ubuntu debian].include?(node[:platform])
     command "git clone https://github.com/nodenv/node-build.git #{nodenv_root}/plugins/node-build"
     not_if "test -d #{nodenv_root}/plugins/node-build"
   end
+else
+  unsupported_platform! node[:platform]
 end
 
 # Install and set the global Node version as two separate resources so a

--- a/mitamae/cookbooks/ocaml/default.rb
+++ b/mitamae/cookbooks/ocaml/default.rb
@@ -17,7 +17,8 @@ if %w[ubuntu debian].include?(node[:platform])
 elsif node[:platform] == 'darwin'
   package 'ocaml'
   package 'opam'
-
+else
+  unsupported_platform! node[:platform]
 end
 
 execute 'Init opam' do

--- a/mitamae/cookbooks/ollama/default.rb
+++ b/mitamae/cookbooks/ollama/default.rb
@@ -7,4 +7,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     not_if 'command -v ollama'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/opencode/default.rb
+++ b/mitamae/cookbooks/opencode/default.rb
@@ -4,4 +4,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   npm_global_package 'opencode-ai' do
     bin_name 'opencode'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/openscad/default.rb
+++ b/mitamae/cookbooks/openscad/default.rb
@@ -4,4 +4,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'openscad' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/ovice/default.rb
+++ b/mitamae/cookbooks/ovice/default.rb
@@ -1,1 +1,5 @@
-brew_cask 'ovice' if node[:platform] == 'darwin'
+if node[:platform] == 'darwin'
+  brew_cask 'ovice'
+else
+  unsupported_platform! node[:platform]
+end

--- a/mitamae/cookbooks/platformio/default.rb
+++ b/mitamae/cookbooks/platformio/default.rb
@@ -5,4 +5,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     command 'uv tool install platformio'
     not_if 'command -v pio || test -f ~/.platformio/penv/bin/pio'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/postico/default.rb
+++ b/mitamae/cookbooks/postico/default.rb
@@ -1,1 +1,5 @@
-brew_cask 'postico' if node[:platform] == 'darwin'
+if node[:platform] == 'darwin'
+  brew_cask 'postico'
+else
+  unsupported_platform! node[:platform]
+end

--- a/mitamae/cookbooks/processing/default.rb
+++ b/mitamae/cookbooks/processing/default.rb
@@ -10,4 +10,6 @@ elsif %w[debian ubuntu].include?(node[:platform])
     user 'root'
     not_if 'snap list | grep -q processing'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/pylsp/default.rb
+++ b/mitamae/cookbooks/pylsp/default.rb
@@ -4,4 +4,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   uv_tool_package 'python-lsp-server' do
     bin_name 'pylsp'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/sdkman/default.rb
+++ b/mitamae/cookbooks/sdkman/default.rb
@@ -22,5 +22,6 @@ if %w[ubuntu debian].include?(node[:platform])
     command "sed -i 's/sdkman_auto_answer=false/sdkman_auto_answer=true/' #{sdkman_dir}/etc/config"
     only_if "grep -q 'sdkman_auto_answer=false' #{sdkman_dir}/etc/config"
   end
-
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/slack/default.rb
+++ b/mitamae/cookbooks/slack/default.rb
@@ -1,1 +1,5 @@
-brew_cask 'slack' if node[:platform] == 'darwin'
+if node[:platform] == 'darwin'
+  brew_cask 'slack'
+else
+  unsupported_platform! node[:platform]
+end

--- a/mitamae/cookbooks/starship/default.rb
+++ b/mitamae/cookbooks/starship/default.rb
@@ -6,4 +6,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     user 'root'
     not_if 'command -v starship'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/stoplight-studio/default.rb
+++ b/mitamae/cookbooks/stoplight-studio/default.rb
@@ -1,1 +1,5 @@
-brew_cask 'stoplight-studio' if node[:platform] == 'darwin'
+if node[:platform] == 'darwin'
+  brew_cask 'stoplight-studio'
+else
+  unsupported_platform! node[:platform]
+end

--- a/mitamae/cookbooks/terraform-ls/default.rb
+++ b/mitamae/cookbooks/terraform-ls/default.rb
@@ -34,4 +34,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'terraform-ls' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/tmux/default.rb
+++ b/mitamae/cookbooks/tmux/default.rb
@@ -2,9 +2,10 @@ if %w[ubuntu debian].include?(node[:platform])
   package 'tmux' do
     user 'root'
   end
-else
-  # macOS, Arch Linux
+elsif %w[darwin arch].include?(node[:platform])
   package 'tmux'
+else
+  unsupported_platform! node[:platform]
 end
 
 home = ENV['HOME']

--- a/mitamae/cookbooks/tree-sitter/default.rb
+++ b/mitamae/cookbooks/tree-sitter/default.rb
@@ -23,6 +23,5 @@ when 'ubuntu', 'debian'
     not_if "test -x #{binary} && #{binary} --version | grep -q '#{tree_sitter_version}'"
   end
 else
-  Mitamae.logger.error "unsupported platform #{node[:platform]}: #{__FILE__}:#{__LINE__}"
-  exit 1
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/tunnelblick/default.rb
+++ b/mitamae/cookbooks/tunnelblick/default.rb
@@ -1,1 +1,5 @@
-brew_cask 'tunnelblick' if node[:platform] == 'darwin'
+if node[:platform] == 'darwin'
+  brew_cask 'tunnelblick'
+else
+  unsupported_platform! node[:platform]
+end

--- a/mitamae/cookbooks/typescript-language-server/default.rb
+++ b/mitamae/cookbooks/typescript-language-server/default.rb
@@ -5,4 +5,6 @@ elsif %w[ubuntu debian].include?(node[:platform])
     bin_name 'tsc'
   end
   npm_global_package 'typescript-language-server'
+else
+  unsupported_platform! node[:platform]
 end

--- a/mitamae/cookbooks/uv/default.rb
+++ b/mitamae/cookbooks/uv/default.rb
@@ -5,6 +5,8 @@ elsif %w[ubuntu debian].include?(node[:platform])
     command 'curl -LsSf https://astral.sh/uv/install.sh | sh'
     not_if 'command -v uv'
   end
+else
+  unsupported_platform! node[:platform]
 end
 
 # Ensure ~/.local/bin is in PATH for subsequent recipes in this mitamae run

--- a/mitamae/cookbooks/zoom/default.rb
+++ b/mitamae/cookbooks/zoom/default.rb
@@ -1,1 +1,5 @@
-brew_cask 'zoom' if node[:platform] == 'darwin'
+if node[:platform] == 'darwin'
+  brew_cask 'zoom'
+else
+  unsupported_platform! node[:platform]
+end

--- a/mitamae/cookbooks/zsh/default.rb
+++ b/mitamae/cookbooks/zsh/default.rb
@@ -7,6 +7,8 @@ elsif %w[ubuntu debian].include?(node[:platform])
   package 'zsh' do
     user 'root'
   end
+else
+  unsupported_platform! node[:platform]
 end
 
 dotfile '.zshenv' do

--- a/mitamae/lib/custom_resources.rb
+++ b/mitamae/lib/custom_resources.rb
@@ -5,6 +5,17 @@ node[:os_arch] = case node[:kernel][:machine]
                  else raise "Unsupported architecture: #{node[:kernel][:machine]}"
                  end
 
+# Abort the run when a cookbook is executed on a platform it does not support.
+#
+# Cookbooks are only ever included in roles whose platform they target, so
+# reaching this means the role/platform combination is misconfigured. Failing
+# loudly surfaces the mistake immediately instead of silently skipping the
+# installation and leaving a half-provisioned host. Pass `node[:platform]` so
+# the message names the offending platform.
+define :unsupported_platform! do
+  raise "Unsupported platform: #{params[:name]}"
+end
+
 # Symlink dotfiles to the user's home directory
 # Pass `cookbook_dir: __dir__` from the calling cookbook so the files/ path resolves correctly.
 define :dotfile, source: nil, cookbook_dir: nil do
@@ -100,6 +111,6 @@ define :cross_platform_package, darwin_name: nil, debian_name: nil do
   elsif node[:platform] == 'darwin'
     package(params[:darwin_name] || pkg)
   else
-    raise "cross_platform_package: unsupported platform '#{node[:platform]}' for package '#{pkg}'"
+    unsupported_platform! node[:platform]
   end
 end


### PR DESCRIPTION
## 背景

未対応platformに対するcookbookの処理について、5系統が混在していました：

1. **黙ってスキップ** — `brew_cask 'x' if node[:platform] == 'darwin'` の一行型 / `if`・`elsif` で `else` 無し
2. **logger.error + exit 1** — `arm-none-eabi-gcc`, `flatcam`, `neovim`, `tree-sitter`
3. **raise** — `arduino-ide`
4. **define 内 raise** — `cross_platform_package`
5. **暗黙 fallthrough** — `git`, `tmux`, `cloudflared`（`else` で macOS/Arch を暗黙処理）

## 変更内容

- `lib/custom_resources.rb` に `unsupported_platform!` ヘルパーを追加し、一貫したメッセージで run を中断するよう統一
- 全 cookbook を本ヘルパー経由に統一
  - 一行 darwin ガードと `else` 無しの `if`/`elsif` は `else unsupported_platform! node[:platform]` で終端
  - logger+exit / raise / define 内 raise は本ヘルパー呼び出しに置換
  - `git` / `tmux` / `cloudflared` は macOS・Arch 対応を維持しつつ対象プラットフォームを明示化し、想定外のプラットフォームでは loud に失敗
- 方針を `cookbooks/README.md` と add-cookbook スキルに明文化

## 方針

> Cookbook は対応プラットフォームを明示的に処理し、それ以外は黙ってスキップせず `unsupported_platform!` で loud に失敗する。

cookbook は対応プラットフォームのロールにのみ含まれるため、ヘルパーに到達する＝ロール/プラットフォームの設定ミス。即座に顕在化させることで、中途半端にプロビジョニングされたホストを防ぎます。

## 互換性

各 cookbook が**従来サポートしていたプラットフォームでの挙動は不変**です。ヘルパーが発火するのは設定ミスのロール/プラットフォーム組み合わせのみで、CI で走る全ロール（macOS: belle/pc137/hercules、Linux: bamboo/pine/palm/plum）は対応プラットフォーム上で実行されるため発火しません。

## 検証

- `bundle exec rubocop`: 100 files, no offenses
- 変更した全 `.rb` の構文チェック通過
- mitamae の `define` 実装を確認し、bang 付き名（`unsupported_platform!`）の登録・recipe 横断呼び出しが安全であることを確認

https://claude.ai/code/session_01CsmtW3dokHQd2yL6R7Uq1Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsmtW3dokHQd2yL6R7Uq1Q)_