### PR TITLE
refactor(mitamae): extract apt_repository define from 7 cookbooks

### DIFF
--- a/.claude/skills/add-cookbook/SKILL.md
+++ b/.claude/skills/add-cookbook/SKILL.md
@@ -75,6 +75,36 @@ cross_platform_package 'sqlite',
 
 Debian installs run as root automatically. Darwin uses brew.
 
+### `apt_repository` — third-party APT repositories (Debian/Ubuntu)
+
+Use inside the Debian/Ubuntu branch when a tool ships via its own APT repo
+instead of the base distro. It fetches the signing key, normalizes it to binary
+with `gpg --dearmor` (works for both armored and already-binary keys), stores it
+at `/etc/apt/keyrings/<name>.gpg`, writes `/etc/apt/sources.list.d/<name>.list`
+(scoped to that key via `signed-by` and pinned to the host arch), and runs
+`apt-get update`. `curl`, `ca-certificates`, and `gnupg` are installed
+automatically. Always prefer this over hand-rolling the key/sources/update dance
+in a raw `execute` — apt's `signed-by` is extension-sensitive, and getting the
+key format wrong silently breaks verification.
+
+```ruby
+apt_repository 'google-chrome' do
+  key_url 'https://dl.google.com/linux/linux_signing_key.pub'
+  repo 'https://dl.google.com/linux/chrome/deb/ stable main'
+end
+
+# A codename-keyed repo embeds shell directly in `repo`:
+codename = '$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")'
+apt_repository 'docker' do
+  key_url "https://download.docker.com/linux/#{node[:platform]}/gpg"
+  repo "https://download.docker.com/linux/#{node[:platform]} #{codename} stable"
+end
+```
+
+`repo` is everything after the `[options]` block of the sources line. Pair it
+with an explicit `package '<name>' do user 'root' end` for the actual install
+and an `unsupported_platform!` fallback for other platforms.
+
 ### `brew_cask` — macOS GUI applications
 
 Only available on macOS. Use for `.app` bundles (not CLI tools). Pair it with

--- a/mitamae/cookbooks/corretto21/default.rb
+++ b/mitamae/cookbooks/corretto21/default.rb
@@ -1,14 +1,9 @@
 if node[:platform] == 'darwin'
   brew_cask 'corretto@21'
 elsif %w[ubuntu debian].include?(node[:platform])
-  execute 'add corretto apt repository' do
-    command <<~EOC
-      curl -fsSL https://apt.corretto.aws/corretto.key | gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg
-      echo "deb [signed-by=/usr/share/keyrings/corretto-keyring.gpg] https://apt.corretto.aws stable main" | tee /etc/apt/sources.list.d/corretto.list
-      apt-get update
-    EOC
-    user 'root'
-    not_if 'test -f /etc/apt/sources.list.d/corretto.list'
+  apt_repository 'corretto' do
+    key_url 'https://apt.corretto.aws/corretto.key'
+    repo 'https://apt.corretto.aws stable main'
   end
 
   package 'java-21-amazon-corretto-jdk' do

--- a/mitamae/cookbooks/docker/default.rb
+++ b/mitamae/cookbooks/docker/default.rb
@@ -1,34 +1,12 @@
 if node[:platform] == 'darwin'
   brew_cask 'docker'
 elsif %w[ubuntu debian].include?(node[:platform])
-  # Prerequisites
-  package 'ca-certificates' do
-    user 'root'
-  end
+  # Docker's repository is keyed by distro codename (e.g. noble/bookworm).
+  codename = '$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")'
 
-  package 'curl' do
-    user 'root'
-  end
-
-  # Add Docker's official GPG key
-  execute 'add docker gpg key' do
-    command <<~EOC
-      install -m 0755 -d /etc/apt/keyrings
-      curl -fsSL https://download.docker.com/linux/#{node[:platform]}/gpg -o /etc/apt/keyrings/docker.asc
-      chmod a+r /etc/apt/keyrings/docker.asc
-    EOC
-    user 'root'
-    not_if 'test -f /etc/apt/keyrings/docker.asc'
-  end
-
-  # Add Docker apt repository
-  execute 'add docker apt repository' do
-    command <<~EOC
-      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/#{node[:platform]} $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-      apt-get update -qq
-    EOC
-    user 'root'
-    not_if 'test -f /etc/apt/sources.list.d/docker.list'
+  apt_repository 'docker' do
+    key_url "https://download.docker.com/linux/#{node[:platform]}/gpg"
+    repo "https://download.docker.com/linux/#{node[:platform]} #{codename} stable"
   end
 
   # Install Docker Engine and plugins

--- a/mitamae/cookbooks/firefox/default.rb
+++ b/mitamae/cookbooks/firefox/default.rb
@@ -1,16 +1,11 @@
 if node[:platform] == 'darwin'
   brew_cask 'firefox'
 elsif %w[ubuntu debian].include?(node[:platform])
-  execute 'Add Mozilla APT repository' do
-    command <<~EOC
-      install -d -m 0755 /etc/apt/keyrings
-      curl -fsSL https://packages.mozilla.org/apt/repo-signing-key.gpg -o /etc/apt/keyrings/packages.mozilla.org.asc
-      echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" > /etc/apt/sources.list.d/mozilla.list
-      apt-get update
-    EOC
-    user 'root'
-    not_if 'test -f /etc/apt/sources.list.d/mozilla.list'
+  apt_repository 'mozilla' do
+    key_url 'https://packages.mozilla.org/apt/repo-signing-key.gpg'
+    repo 'https://packages.mozilla.org/apt mozilla main'
   end
+
   package 'firefox' do
     user 'root'
   end

--- a/mitamae/cookbooks/gh/default.rb
+++ b/mitamae/cookbooks/gh/default.rb
@@ -1,17 +1,9 @@
 if node[:platform] == 'darwin'
   package 'gh'
 elsif %w[ubuntu debian].include?(node[:platform])
-  execute 'Add GitHub CLI apt repository' do
-    command <<~EOC
-      curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-      chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-        | tee /etc/apt/sources.list.d/github-cli.list
-      apt-get update
-    EOC
-    user 'root'
-    not_if 'test -f /etc/apt/sources.list.d/github-cli.list'
+  apt_repository 'github-cli' do
+    key_url 'https://cli.github.com/packages/githubcli-archive-keyring.gpg'
+    repo 'https://cli.github.com/packages stable main'
   end
 
   package 'gh' do

--- a/mitamae/cookbooks/google-chrome/default.rb
+++ b/mitamae/cookbooks/google-chrome/default.rb
@@ -1,15 +1,11 @@
 if node[:platform] == 'darwin'
   brew_cask 'google-chrome'
 elsif %w[ubuntu debian].include?(node[:platform])
-  execute 'Add Google Chrome APT repository' do
-    command <<~EOC
-      curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
-      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
-      apt-get update
-    EOC
-    user 'root'
-    not_if 'test -f /etc/apt/sources.list.d/google-chrome.list'
+  apt_repository 'google-chrome' do
+    key_url 'https://dl.google.com/linux/linux_signing_key.pub'
+    repo 'https://dl.google.com/linux/chrome/deb/ stable main'
   end
+
   package 'google-chrome-stable' do
     user 'root'
   end

--- a/mitamae/cookbooks/google-cloud-sdk/default.rb
+++ b/mitamae/cookbooks/google-cloud-sdk/default.rb
@@ -2,20 +2,9 @@ if node[:platform] == 'darwin'
   brew_cask 'google-cloud-sdk'
 elsif %w[ubuntu debian].include?(node[:platform])
   # Official installation guide: https://cloud.google.com/sdk/docs/install-sdk#debian_and_ubuntu
-  %w[apt-transport-https ca-certificates gnupg curl].each do |pkg|
-    package pkg do
-      user 'root'
-    end
-  end
-
-  execute 'Add Google Cloud SDK APT repository' do
-    command <<~EOC
-      curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/google-cloud.gpg
-      echo "deb [signed-by=/usr/share/keyrings/google-cloud.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list
-      apt-get update
-    EOC
-    user 'root'
-    not_if 'test -f /etc/apt/sources.list.d/google-cloud-sdk.list'
+  apt_repository 'google-cloud-sdk' do
+    key_url 'https://packages.cloud.google.com/apt/doc/apt-key.gpg'
+    repo 'https://packages.cloud.google.com/apt cloud-sdk main'
   end
 
   package 'google-cloud-cli' do

--- a/mitamae/cookbooks/terraform-ls/default.rb
+++ b/mitamae/cookbooks/terraform-ls/default.rb
@@ -1,36 +1,14 @@
 if node[:platform] == 'darwin'
   package 'hashicorp/tap/terraform-ls'
 elsif %w[ubuntu debian].include?(node[:platform])
-  package 'gnupg' do
-    user 'root'
-  end
-  package 'curl' do
-    user 'root'
+  # HashiCorp's repository is keyed by distro codename (e.g. noble/bookworm).
+  codename = '$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")'
+
+  apt_repository 'hashicorp' do
+    key_url 'https://apt.releases.hashicorp.com/gpg'
+    repo "https://apt.releases.hashicorp.com #{codename} main"
   end
 
-  # Official way for debian/ubuntu
-  execute 'Add HashiCorp GPG key' do
-    command 'curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg'
-    user 'root'
-    not_if 'test -f /usr/share/keyrings/hashicorp-archive-keyring.gpg'
-  end
-
-  execute 'Add HashiCorp repo' do
-    key = '/usr/share/keyrings/hashicorp-archive-keyring.gpg'
-    url = 'https://apt.releases.hashicorp.com'
-    codename = '$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")'
-    sources_list = '/etc/apt/sources.list.d/hashicorp.list'
-    command "echo \"deb [arch=$(dpkg --print-architecture) signed-by=#{key}] #{url} #{codename} main\" > #{sources_list}"
-    user 'root'
-    not_if 'test -f /etc/apt/sources.list.d/hashicorp.list'
-    notifies :run, 'execute[apt-get update for hashicorp]', :immediately
-  end
-
-  execute 'apt-get update for hashicorp' do
-    command 'apt-get update'
-    user 'root'
-    action :nothing
-  end
   package 'terraform-ls' do
     user 'root'
   end

--- a/mitamae/lib/custom_resources.rb
+++ b/mitamae/lib/custom_resources.rb
@@ -100,6 +100,52 @@ define :npm_global_package, version: nil, bin_name: nil do
   end
 end
 
+# Configure a third-party APT repository on Debian/Ubuntu.
+#
+# Centralizes the "fetch signing key -> write sources.list -> apt-get update"
+# boilerplate that every external-repo cookbook used to hand-roll, where the
+# keyring location and arch pinning drifted arbitrarily. The signing key is
+# normalized to binary with `gpg --dearmor` (which accepts both ASCII-armored
+# and already-binary keys) and stored under /etc/apt/keyrings as `<name>.gpg`.
+# Normalizing matters: apt's `signed-by` is extension-sensitive and rejects an
+# armored key behind a `.gpg` name (NO_PUBKEY), so always dearmoring is what
+# lets a single `.gpg` convention work for every upstream key. The source is
+# scoped to that key via `signed-by` and pinned to the host architecture.
+#
+#   apt_repository 'docker' do
+#     key_url "https://download.docker.com/linux/#{node[:platform]}/gpg"
+#     repo    "https://download.docker.com/linux/#{node[:platform]} stable"
+#   end
+#
+# `repo` is everything after the `[options]` block of the sources line, so it
+# may embed shell (e.g. the distro codename via `$(. /etc/os-release; ...)`).
+define :apt_repository, key_url: nil, repo: nil do
+  name = params[:name]
+  keyring = "/etc/apt/keyrings/#{name}.gpg"
+  list = "/etc/apt/sources.list.d/#{name}.list"
+
+  # The command below relies on curl (download), ca-certificates (TLS), and
+  # gnupg (`gpg --dearmor`). Install them explicitly so the cookbook works on a
+  # minimal base image instead of assuming these tools happen to be present.
+  %w[ca-certificates curl gnupg].each do |pkg|
+    package pkg do
+      user 'root'
+    end
+  end
+
+  execute "Add #{name} APT repository" do
+    command <<~EOC
+      install -d -m 0755 /etc/apt/keyrings
+      curl -fsSL #{params[:key_url]} | gpg --dearmor --yes -o #{keyring}
+      chmod a+r #{keyring}
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=#{keyring}] #{params[:repo]}" > #{list}
+      apt-get update
+    EOC
+    user 'root'
+    not_if "test -f #{list}"
+  end
+end
+
 # Install a system package with platform-specific name overrides
 # Automatically handles debian/ubuntu vs darwin platform differences.
 # Supports packages with the same name across platforms (e.g., ffmpeg)


### PR DESCRIPTION
## Summary

Addresses the review finding that the `gh`, `docker`, `terraform-ls`, `firefox`, `google-chrome`, `corretto21`, and `google-cloud-sdk` cookbooks each hand-rolled the same "fetch signing key → write sources.list → apt-get update" sequence, with the keyring location, dearmor handling, and arch pinning drifting between them for no real reason.

A new `apt_repository` define is added to `mitamae/lib/custom_resources.rb` and all seven cookbooks now use it.

```ruby
apt_repository 'google-chrome' do
  key_url 'https://dl.google.com/linux/linux_signing_key.pub'
  repo 'https://dl.google.com/linux/chrome/deb/ stable main'
end
```

## Validating the review's proposed snippet

The proposal suggested a `dearmor:` parameter that, when `false`, would store the key verbatim into a `.gpg` file. **I verified this is a latent bug** and dropped the parameter instead:

- apt's `signed-by` is **extension-sensitive**. Storing an ASCII-armored key behind a `.gpg` filename fails verification with `NO_PUBKEY` (confirmed end-to-end against `download.docker.com`).
- `docker` and `firefox`/`mozilla` ship **armored** keys but were previously stored as `.asc` (no dearmor). Under the proposed `dearmor: false` + `.gpg` convention they would have silently broken.
- `gpg --dearmor` accepts **both** armored and already-binary keys and is idempotent on binary input, so always dearmoring normalizes every upstream key to binary — making a single `.gpg` convention correct for all seven repos.

So the define **always** runs `gpg --dearmor`, drops the footgun parameter, and keeps the rest of the review's intent (centralized boilerplate, `/etc/apt/keyrings`, `signed-by`, arch pinning).

## Behavior notes

- Keyrings move to `/etc/apt/keyrings/<name>.gpg`. On already-provisioned hosts the `not_if test -f <list>` guard means nothing re-runs, so existing installs keep working.
- The define installs `curl`, `ca-certificates`, and `gnupg` itself rather than assuming the base image provides them (previously `corretto21` relied on `gnupg` being transitively present). The obsolete `apt-transport-https` prerequisite was dropped.
- `docker` and `terraform-ls` keep their distro-codename-keyed repo lines via shell embedded in `repo`.

## Testing

- `rubocop` clean (100 files, no offenses).
- `mitamae --dry-run` expands the define correctly.
- End-to-end: fetched docker's real armored key, `gpg --dearmor`'d it into `/etc/apt/keyrings/*.gpg`, and confirmed `apt-get update` verifies the repo (exit 0). Also confirmed the armored-key-as-`.gpg` failure mode and that `.asc`/dearmored-`.gpg` both succeed.
- CI exercises `docker`/`gh`/`terraform-ls` (bamboo, pine, palm) and `corretto21`/`google-cloud-sdk` (palm) on Linux via the Docker/LXC builds.

The `apt_repository` helper is also documented in the add-cookbook skill.

https://claude.ai/code/session_012bjbCHz1sjj3WRLcDvWkNV

---
_Generated by [Claude Code](https://claude.ai/code/session_012bjbCHz1sjj3WRLcDvWkNV)_