### PR TITLE
feat(claude-code): allow pyright via uv in user permissions

### DIFF
--- a/mitamae/cookbooks/claude-code/files/settings.json
+++ b/mitamae/cookbooks/claude-code/files/settings.json
@@ -138,6 +138,7 @@
       "Bash(uv run pytest *)",
       "Bash(uv run python -m pytest *)",
       "Bash(uv run ruff *)",
+      "Bash(uv run pyright *)",
       "Bash(uv sync *)",
       "Bash(uv lock *)",
       "Bash(uv add *)",


### PR DESCRIPTION
## Summary
- Add `Bash(uv run pyright *)` to the Claude Code user-scope `permissions.allow` list so pyright can run through `uv` without a prompt.

## Why
Pyright is invoked via `uv run pyright`, consistent with the existing `uv run ruff` / `uv run pytest` allowances, but was not yet permitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)