### PR TITLE
Add terraform cookbook to hercules role

### DIFF
--- a/mitamae/cookbooks/terraform/default.rb
+++ b/mitamae/cookbooks/terraform/default.rb
@@ -1,0 +1,17 @@
+if node[:platform] == 'darwin'
+  package 'hashicorp/tap/terraform'
+elsif %w[ubuntu debian].include?(node[:platform])
+  # HashiCorp's repository is keyed by distro codename (e.g. noble/bookworm).
+  codename = '$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")'
+
+  apt_repository 'hashicorp' do
+    key_url 'https://apt.releases.hashicorp.com/gpg'
+    repo "https://apt.releases.hashicorp.com #{codename} main"
+  end
+
+  package 'terraform' do
+    user 'root'
+  end
+else
+  unsupported_platform! node[:platform]
+end

--- a/mitamae/cookbooks/terraform/goss.yaml
+++ b/mitamae/cookbooks/terraform/goss.yaml
@@ -1,0 +1,4 @@
+command:
+  terraform version:
+    exit-status: 0
+    timeout: 5000

--- a/mitamae/roles/hercules/default.rb
+++ b/mitamae/roles/hercules/default.rb
@@ -42,6 +42,7 @@ include_recipe '../../cookbooks/nmap'
 # Cloud & DevOps
 include_recipe '../../cookbooks/awscli'
 include_recipe '../../cookbooks/cfn-lint'
+include_recipe '../../cookbooks/terraform'
 include_recipe '../../cookbooks/gh'
 include_recipe '../../cookbooks/docker'
 include_recipe '../../cookbooks/devcontainer-cli'

--- a/mitamae/roles/hercules/goss.yaml
+++ b/mitamae/roles/hercules/goss.yaml
@@ -19,6 +19,7 @@ gossfile:
   ../../cookbooks/nmap/goss.yaml: {}
   ../../cookbooks/awscli/goss.yaml: {}
   ../../cookbooks/cfn-lint/goss.yaml: {}
+  ../../cookbooks/terraform/goss.yaml: {}
   ../../cookbooks/gh/goss.yaml: {}
   ../../cookbooks/docker/goss.yaml: {}
   ../../cookbooks/devcontainer-cli/goss.yaml: {}


### PR DESCRIPTION
## Summary
- Add a new `terraform` cookbook that installs Terraform via HashiCorp's official repositories, mirroring the existing `terraform-ls` cookbook:
  - macOS: `hashicorp/tap/terraform` (brew tap)
  - Debian/Ubuntu: register the HashiCorp APT repository and install the `terraform` package
  - Other platforms fail loudly via `unsupported_platform!`
- Register the cookbook and its goss health check in the `hercules` role.

Installing through the official repositories keeps Terraform at the latest stable release, so no version pinning is required.

## Test plan
- `bundle exec rubocop` — 101 files inspected, no offenses detected
- `goss.yaml` validates `terraform version` exits 0

https://claude.ai/code/session_01J7PCw59EFPmoN92xaLhGh1

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7PCw59EFPmoN92xaLhGh1)_